### PR TITLE
Add deprecation notice for V1 API endpoints

### DIFF
--- a/source/extensions/mollie/api_name_directive.py
+++ b/source/extensions/mollie/api_name_directive.py
@@ -1,8 +1,6 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
-from source.extensions import utilities
-
 
 class ApiNameDirective(Directive):
     has_content = False
@@ -23,5 +21,22 @@ class ApiNameDirective(Directive):
             api_version_line["classes"].append("api-name__version")
 
             api_name_line += [api_version_line]
+
+            if self.options["version"] == 1:
+                warning_node = nodes.warning()
+
+                warning_text = nodes.line_block()
+                warning_par_1 = nodes.paragraph(text=
+                    "The v1 API has been deprecated. New features will go into the "
+                    "v2 API. We're recommending all new implementations to be built "
+                    "on top of the v2 API.")
+                warning_par_2 = nodes.paragraph(text=
+                    "The v1 API will be supported for the foreseeable future, at "
+                    "least until July 2023.")
+                warning_text += [warning_par_1, warning_par_2]
+
+                warning_node += warning_text
+
+                return [api_name_line, warning_node]
 
         return [api_name_line]

--- a/source/extensions/mollie/api_name_directive.py
+++ b/source/extensions/mollie/api_name_directive.py
@@ -22,21 +22,4 @@ class ApiNameDirective(Directive):
 
             api_name_line += [api_version_line]
 
-            if self.options["version"] == 1:
-                warning_node = nodes.warning()
-
-                warning_text = nodes.line_block()
-                warning_par_1 = nodes.paragraph(text=
-                    "The v1 API has been deprecated. New features will go into the "
-                    "v2 API. We're recommending all new implementations to be built "
-                    "on top of the v2 API.")
-                warning_par_2 = nodes.paragraph(text=
-                    "The v1 API will be supported for the foreseeable future, at "
-                    "least until July 2023.")
-                warning_text += [warning_par_1, warning_par_2]
-
-                warning_node += warning_text
-
-                return [api_name_line, warning_node]
-
         return [api_name_line]

--- a/source/reference/v1/chargebacks-api/get-chargeback.rst
+++ b/source/reference/v1/chargebacks-api/get-chargeback.rst
@@ -3,9 +3,12 @@ Get chargeback
 .. api-name:: Chargebacks API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving chargebacks in the new v2 API can
-             be found :doc:`here </reference/v2/chargebacks-api/get-chargeback>`. For more information on the v2 API,
-             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving chargebacks in the new v2 API can be found
+             :doc:`here </reference/v2/chargebacks-api/get-chargeback>`. For more information on the v2 API, refer to
+             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v1/chargebacks-api/list-chargebacks.rst
@@ -3,9 +3,13 @@ List chargebacks
 .. api-name:: Chargebacks API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing chargebacks in the new v2 API can be
-             found :doc:`here </reference/v2/chargebacks-api/list-chargebacks>`. For more information on the v2 API,
-             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing chargebacks in the new v2 API can be found
+             :doc:`here </reference/v2/chargebacks-api/list-chargebacks>`. For more information on the v2 API, refer to
+             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v1/chargebacks-api/list-chargebacks.rst
@@ -3,7 +3,6 @@ List chargebacks
 .. api-name:: Chargebacks API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/customers-api/create-customer-payment.rst
+++ b/source/reference/v1/customers-api/create-customer-payment.rst
@@ -3,9 +3,12 @@ Create customer payment
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for creating payments for a customer in the new
-             v2 API can be found :doc:`here </reference/v2/customers-api/create-customer-payment>`. For more information
-             on the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for creating payments for a customer in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/create-customer-payment>`. For more information on the v2 API,
+             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/customers-api/create-customer.rst
+++ b/source/reference/v1/customers-api/create-customer.rst
@@ -3,9 +3,12 @@ Create customer
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for creating customers in the new v2 API can be
-             found :doc:`here </reference/v2/customers-api/create-customer>`. For more information on the v2 API, refer
-             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for creating customers in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/create-customer>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/customers-api/delete-customer.rst
+++ b/source/reference/v1/customers-api/delete-customer.rst
@@ -3,9 +3,12 @@ Delete customer
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for deleting customers in the new v2 API can be
-             found :doc:`here </reference/v2/customers-api/delete-customer>`. For more information on the v2 API, refer
-             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for deleting customers in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/delete-customer>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: DELETE

--- a/source/reference/v1/customers-api/get-customer.rst
+++ b/source/reference/v1/customers-api/get-customer.rst
@@ -3,9 +3,12 @@ Get customer
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving customers in the new v2 API can
-             be found :doc:`here </reference/v2/customers-api/get-customer>`. For more information on the v2 API, refer
-             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving customers in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/get-customer>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/customers-api/list-customer-payments.rst
+++ b/source/reference/v1/customers-api/list-customer-payments.rst
@@ -3,7 +3,6 @@ List customer payments
 .. api-name:: Customers API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/customers-api/list-customer-payments.rst
+++ b/source/reference/v1/customers-api/list-customer-payments.rst
@@ -3,9 +3,13 @@ List customer payments
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing payments of a customer in the new v2
-             API can be found :doc:`here </reference/v2/customers-api/list-customer-payments>`. For more information on
-             the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing payments of a customer in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/list-customer-payments>`. For more information on the v2 API, refer
+             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/customers-api/list-customers.rst
+++ b/source/reference/v1/customers-api/list-customers.rst
@@ -3,7 +3,6 @@ List customers
 .. api-name:: Customers API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/customers-api/list-customers.rst
+++ b/source/reference/v1/customers-api/list-customers.rst
@@ -3,9 +3,13 @@ List customers
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing customers in the new v2 API can be
-             found :doc:`here </reference/v2/customers-api/list-customers>`. For more information on the v2 API, refer
-             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing customers in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/list-customers>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/customers-api/update-customer.rst
+++ b/source/reference/v1/customers-api/update-customer.rst
@@ -3,9 +3,12 @@ Update customer
 .. api-name:: Customers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for updating customers in the new v2 API can be
-             found :doc:`here </reference/v2/customers-api/update-customer>`. For more information on the v2 API, refer
-             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for updating customers in the new v2 API can be found
+             :doc:`here </reference/v2/customers-api/update-customer>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/issuers-api/get-issuer.rst
+++ b/source/reference/v1/issuers-api/get-issuer.rst
@@ -3,10 +3,13 @@ Get issuer
 .. api-name:: Issuers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The new v2 API no longer supports retrieving issuers separately.
-             Instead, issuers can be retrieved by using the ``issuers`` include on the Methods API. Documentation for
-             the Methods API v2 can be found :doc:`here </reference/v2/methods-api/list-methods>`. For more information
-             on the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The new v2 API no longer supports retrieving issuers separately. Instead, issuers can be retrieved by using
+             the ``issuers`` include on the Methods API. Documentation for the Methods API v2 can be found
+             :doc:`here </reference/v2/methods-api/list-methods>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/issuers-api/list-issuers.rst
+++ b/source/reference/v1/issuers-api/list-issuers.rst
@@ -3,10 +3,12 @@ List issuers
 .. api-name:: Issuers API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. In the new v2 API, issuers can be retrieved by using the
-             ``issuers`` include on the Methods API. Documentation for the Methods API v2 can be found
-             :doc:`here </reference/v2/methods-api/list-methods>`. For more information on the v2 API, refer to our
-             :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             In the new v2 API, issuers can be retrieved by using the ``issuers`` include on the Methods API.
+             Documentation for the Methods API v2 can be found :doc:`here </reference/v2/methods-api/list-methods>`. For
+             more information on the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/mandates-api/create-mandate.rst
+++ b/source/reference/v1/mandates-api/create-mandate.rst
@@ -3,7 +3,6 @@ Create mandate
 .. api-name:: Mandates API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/mandates-api/create-mandate.rst
+++ b/source/reference/v1/mandates-api/create-mandate.rst
@@ -3,9 +3,13 @@ Create mandate
 .. api-name:: Mandates API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for creating mandates in the new v2 API can be
-             found :doc:`here </reference/v2/mandates-api/create-mandate>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for creating mandates in the new v2 API can be found
+             :doc:`here </reference/v2/mandates-api/create-mandate>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/mandates-api/get-mandate.rst
+++ b/source/reference/v1/mandates-api/get-mandate.rst
@@ -3,9 +3,12 @@ Get mandate
 .. api-name:: Mandates API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving mandates in the new v2 API can be
-             found :doc:`here </reference/v2/mandates-api/get-mandate>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving mandates in the new v2 API can be found
+             :doc:`here </reference/v2/mandates-api/get-mandate>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/mandates-api/list-mandates.rst
+++ b/source/reference/v1/mandates-api/list-mandates.rst
@@ -3,7 +3,6 @@ List mandates
 .. api-name:: Mandates API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/mandates-api/list-mandates.rst
+++ b/source/reference/v1/mandates-api/list-mandates.rst
@@ -3,9 +3,13 @@ List mandates
 .. api-name:: Mandates API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing mandates in the new v2 API can be
-             found :doc:`here </reference/v2/mandates-api/list-mandates>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing mandates in the new v2 API can be found
+             :doc:`here </reference/v2/mandates-api/list-mandates>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/mandates-api/revoke-mandate.rst
+++ b/source/reference/v1/mandates-api/revoke-mandate.rst
@@ -3,9 +3,13 @@ Revoke mandate
 .. api-name:: Mandates API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for revoking mandates in the new v2 API can be
-             found :doc:`here </reference/v2/mandates-api/revoke-mandate>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for revoking mandates in the new v2 API can be found
+             :doc:`here </reference/v2/mandates-api/revoke-mandate>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: DELETE

--- a/source/reference/v1/mandates-api/revoke-mandate.rst
+++ b/source/reference/v1/mandates-api/revoke-mandate.rst
@@ -3,7 +3,6 @@ Revoke mandate
 .. api-name:: Mandates API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/methods-api/get-method.rst
+++ b/source/reference/v1/methods-api/get-method.rst
@@ -3,7 +3,6 @@ Get payment method
 .. api-name:: Methods API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/methods-api/get-method.rst
+++ b/source/reference/v1/methods-api/get-method.rst
@@ -3,9 +3,13 @@ Get payment method
 .. api-name:: Methods API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving payment methods in the new v2 API
-             can be found :doc:`here </reference/v2/methods-api/get-method>`. For more information on the v2 API, refer
-             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving payment methods in the new v2 API can be found
+             :doc:`here </reference/v2/methods-api/get-method>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/methods-api/list-methods.rst
+++ b/source/reference/v1/methods-api/list-methods.rst
@@ -3,9 +3,13 @@ List payment methods
 .. api-name:: Methods API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing payment methods in the new v2 API
-             can be found :doc:`here </reference/v2/methods-api/list-methods>`. For more information on the v2 API,
-             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing payment methods in the new v2 API can be found
+             :doc:`here </reference/v2/methods-api/list-methods>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/methods-api/list-methods.rst
+++ b/source/reference/v1/methods-api/list-methods.rst
@@ -3,7 +3,6 @@ List payment methods
 .. api-name:: Methods API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/organizations-api/get-organization.rst
+++ b/source/reference/v1/organizations-api/get-organization.rst
@@ -3,7 +3,6 @@ Get organization
 .. api-name:: Organizations API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/organizations-api/get-organization.rst
+++ b/source/reference/v1/organizations-api/get-organization.rst
@@ -3,9 +3,13 @@ Get organization
 .. api-name:: Organizations API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving organizations in the new v2 API
-             can be found :doc:`here </reference/v2/organizations-api/get-organization>`. For more information on the v2
-             API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving organizations in the new v2 API can be found
+             :doc:`here </reference/v2/organizations-api/get-organization>`. For more information on the v2 API, refer
+             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/payments-api/cancel-payment.rst
+++ b/source/reference/v1/payments-api/cancel-payment.rst
@@ -3,11 +3,10 @@ Cancel payment
 .. api-name:: Payments API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 
-             The documentation for cancelling payments in the new v2 API can be found
+             The documentation for canceling payments in the new v2 API can be found
              :doc:`here </reference/v2/payments-api/cancel-payment>`. For more information on the v2 API, refer to our
              :doc:`v2 migration guide </migrating-v1-to-v2>`.
 

--- a/source/reference/v1/payments-api/cancel-payment.rst
+++ b/source/reference/v1/payments-api/cancel-payment.rst
@@ -3,9 +3,13 @@ Cancel payment
 .. api-name:: Payments API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for cancelling payments in the new v2 API can be
-             found :doc:`here </reference/v2/payments-api/cancel-payment>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for cancelling payments in the new v2 API can be found
+             :doc:`here </reference/v2/payments-api/cancel-payment>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: DELETE

--- a/source/reference/v1/payments-api/create-payment.rst
+++ b/source/reference/v1/payments-api/create-payment.rst
@@ -3,7 +3,6 @@ Create payment
 .. api-name:: Payments API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/payments-api/create-payment.rst
+++ b/source/reference/v1/payments-api/create-payment.rst
@@ -3,9 +3,13 @@ Create payment
 .. api-name:: Payments API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for creating payments in the new v2 API can be
-             found :doc:`here </reference/v2/payments-api/create-payment>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for creating payments in the new v2 API can be found
+             :doc:`here </reference/v2/payments-api/create-payment>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/payments-api/get-payment.rst
+++ b/source/reference/v1/payments-api/get-payment.rst
@@ -3,9 +3,13 @@ Get payment
 .. api-name:: Payments API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving payments in the new v2 API can be
-             found :doc:`here </reference/v2/payments-api/get-payment>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving payments in the new v2 API can be found
+             :doc:`here </reference/v2/payments-api/get-payment>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/payments-api/get-payment.rst
+++ b/source/reference/v1/payments-api/get-payment.rst
@@ -3,7 +3,6 @@ Get payment
 .. api-name:: Payments API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/payments-api/list-payments.rst
+++ b/source/reference/v1/payments-api/list-payments.rst
@@ -3,9 +3,13 @@ List payments
 .. api-name:: Payments API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing payments in the new v2 API can be
-             found :doc:`here </reference/v2/payments-api/list-payments>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing payments in the new v2 API can be found
+             :doc:`here </reference/v2/payments-api/list-payments>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/payments-api/list-payments.rst
+++ b/source/reference/v1/payments-api/list-payments.rst
@@ -3,7 +3,6 @@ List payments
 .. api-name:: Payments API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/refunds-api/cancel-refund.rst
+++ b/source/reference/v1/refunds-api/cancel-refund.rst
@@ -3,9 +3,13 @@ Cancel refund
 .. api-name:: Refunds API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for canceling refunds in the new v2 API can be
-             found :doc:`here </reference/v2/refunds-api/cancel-refund>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for canceling refunds in the new v2 API can be found
+             :doc:`here </reference/v2/refunds-api/cancel-refund>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: DELETE

--- a/source/reference/v1/refunds-api/cancel-refund.rst
+++ b/source/reference/v1/refunds-api/cancel-refund.rst
@@ -3,7 +3,6 @@ Cancel refund
 .. api-name:: Refunds API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/refunds-api/create-refund.rst
+++ b/source/reference/v1/refunds-api/create-refund.rst
@@ -3,7 +3,6 @@ Create refund
 .. api-name:: Refunds API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/refunds-api/create-refund.rst
+++ b/source/reference/v1/refunds-api/create-refund.rst
@@ -3,9 +3,13 @@ Create refund
 .. api-name:: Refunds API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for creating refunds in the new v2 API can be
-             found :doc:`here </reference/v2/refunds-api/create-refund>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for creating refunds in the new v2 API can be found
+             :doc:`here </reference/v2/refunds-api/create-refund>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/refunds-api/get-refund.rst
+++ b/source/reference/v1/refunds-api/get-refund.rst
@@ -3,7 +3,6 @@ Get refund
 .. api-name:: Refunds API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/refunds-api/get-refund.rst
+++ b/source/reference/v1/refunds-api/get-refund.rst
@@ -3,8 +3,12 @@ Get refund
 .. api-name:: Refunds API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving refunds in the new v2 API can be
-             found :doc:`here </reference/v2/refunds-api/get-refund>`. For more information on the v2 API, refer to our
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving refunds in the new v2 API can be found
+             :doc:`here </reference/v2/refunds-api/get-refund>`. For more information on the v2 API, refer to our
              :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::

--- a/source/reference/v1/refunds-api/list-refunds.rst
+++ b/source/reference/v1/refunds-api/list-refunds.rst
@@ -3,7 +3,6 @@ List refunds
 .. api-name:: Refunds API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 
@@ -14,7 +13,6 @@ List refunds
 .. endpoint::
    :method: GET
    :url: https://api.mollie.com/v1/refunds
-
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/refunds-api/list-refunds.rst
+++ b/source/reference/v1/refunds-api/list-refunds.rst
@@ -3,9 +3,13 @@ List refunds
 .. api-name:: Refunds API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing refunds in the new v2 API can be
-             found :doc:`here </reference/v2/refunds-api/list-refunds>`. For more information on the v2 API, refer to
-             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing refunds in the new v2 API can be found
+             :doc:`here </reference/v2/refunds-api/list-refunds>`. For more information on the v2 API, refer to our
+             :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/get-next-settlement.rst
+++ b/source/reference/v1/settlements-api/get-next-settlement.rst
@@ -3,7 +3,6 @@ Get next settlement
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/settlements-api/get-next-settlement.rst
+++ b/source/reference/v1/settlements-api/get-next-settlement.rst
@@ -3,9 +3,13 @@ Get next settlement
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving the next settlement in the new v2
-             API can be found :doc:`here </reference/v2/settlements-api/get-next-settlement>`. For more information on
-             the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving the next settlement in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/get-next-settlement>`. For more information on the v2 API, refer
+             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/get-open-settlement.rst
+++ b/source/reference/v1/settlements-api/get-open-settlement.rst
@@ -3,9 +3,13 @@ Get open settlement
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving the open settlement in the new v2
-             API can be found :doc:`here </reference/v2/settlements-api/get-open-settlement>`. For more information on
-             the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving the open settlement in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/get-open-settlement>`. For more information on the v2 API, refer
+             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/get-open-settlement.rst
+++ b/source/reference/v1/settlements-api/get-open-settlement.rst
@@ -3,7 +3,6 @@ Get open settlement
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/settlements-api/get-settlement.rst
+++ b/source/reference/v1/settlements-api/get-settlement.rst
@@ -3,7 +3,6 @@ Get settlement
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/settlements-api/get-settlement.rst
+++ b/source/reference/v1/settlements-api/get-settlement.rst
@@ -3,9 +3,13 @@ Get settlement
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving settlements in the new v2 API can
-             be found :doc:`here </reference/v2/settlements-api/get-settlement>`. For more information on the v2 API,
-             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving settlements in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/get-settlement>`. For more information on the v2 API, refer to
+             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/list-settlement-chargebacks.rst
+++ b/source/reference/v1/settlements-api/list-settlement-chargebacks.rst
@@ -3,9 +3,13 @@ List settlement chargebacks
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing chargebacks included in a settlement
-             in the new v2 API can be found :doc:`here </reference/v2/settlements-api/list-settlement-chargebacks>`. For
-             more information on the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing chargebacks included in a settlement in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/list-settlement-chargebacks>`. For more information on the v2
+             API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/list-settlement-chargebacks.rst
+++ b/source/reference/v1/settlements-api/list-settlement-chargebacks.rst
@@ -3,7 +3,6 @@ List settlement chargebacks
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/settlements-api/list-settlement-payments.rst
+++ b/source/reference/v1/settlements-api/list-settlement-payments.rst
@@ -3,9 +3,13 @@ List settlement payments
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing payments included in a settlement
-             in the new v2 API can be found :doc:`here </reference/v2/settlements-api/list-settlement-payments>`. For
-             more information on the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing payments included in a settlement in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/list-settlement-payments>`. For more information on the v2 API,
+             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/list-settlement-payments.rst
+++ b/source/reference/v1/settlements-api/list-settlement-payments.rst
@@ -3,7 +3,6 @@ List settlement payments
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/settlements-api/list-settlement-refunds.rst
+++ b/source/reference/v1/settlements-api/list-settlement-refunds.rst
@@ -3,7 +3,6 @@ List settlement refunds
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/settlements-api/list-settlement-refunds.rst
+++ b/source/reference/v1/settlements-api/list-settlement-refunds.rst
@@ -3,9 +3,13 @@ List settlement refunds
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing refunds included in a settlement in
-             the new v2 API can be found :doc:`here </reference/v2/settlements-api/list-settlement-refunds>`. For more
-             information on the v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing refunds included in a settlement in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/list-settlement-refunds>`. For more information on the v2 API,
+             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/list-settlements.rst
+++ b/source/reference/v1/settlements-api/list-settlements.rst
@@ -3,9 +3,13 @@ List settlements
 .. api-name:: Settlements API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing settlements in the new v2 API can be
-             found :doc:`here </reference/v2/settlements-api/list-settlements>`. For more information on the v2 API,
-             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing settlements in the new v2 API can be found
+             :doc:`here </reference/v2/settlements-api/list-settlements>`. For more information on the v2 API, refer to
+             our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/settlements-api/list-settlements.rst
+++ b/source/reference/v1/settlements-api/list-settlements.rst
@@ -3,7 +3,6 @@ List settlements
 .. api-name:: Settlements API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/subscriptions-api/cancel-subscription.rst
+++ b/source/reference/v1/subscriptions-api/cancel-subscription.rst
@@ -3,7 +3,6 @@ Cancel subscription
 .. api-name:: Subscriptions API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/subscriptions-api/cancel-subscription.rst
+++ b/source/reference/v1/subscriptions-api/cancel-subscription.rst
@@ -3,9 +3,13 @@ Cancel subscription
 .. api-name:: Subscriptions API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for canceling subscriptions in the new v2 API
-             can be found :doc:`here </reference/v2/subscriptions-api/cancel-subscription>`. For more information on the
-             v2 API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for canceling subscriptions in the new v2 API can be found
+             :doc:`here </reference/v2/subscriptions-api/cancel-subscription>`. For more information on the v2 API,
+             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: DELETE

--- a/source/reference/v1/subscriptions-api/create-subscription.rst
+++ b/source/reference/v1/subscriptions-api/create-subscription.rst
@@ -3,7 +3,6 @@ Create subscription
 .. api-name:: Subscriptions API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/subscriptions-api/create-subscription.rst
+++ b/source/reference/v1/subscriptions-api/create-subscription.rst
@@ -3,9 +3,13 @@ Create subscription
 .. api-name:: Subscriptions API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for creating subscriptions in the new v2 API can
-             be found :doc:`here </reference/v2/subscriptions-api/create-subscription>`. For more information on the v2
-             API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for creating subscriptions in the new v2 API can be found
+             :doc:`here </reference/v2/subscriptions-api/create-subscription>`. For more information on the v2 API,
+             refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v1/subscriptions-api/get-subscription.rst
+++ b/source/reference/v1/subscriptions-api/get-subscription.rst
@@ -3,9 +3,13 @@ Get subscription
 .. api-name:: Subscriptions API
    :version: 1
 
-.. warning:: This is the documentation of the v1 API. The documentation for retrieving subscriptions in the new v2 API
-             can be found :doc:`here </reference/v2/subscriptions-api/get-subscription>`. For more information on the v2
-             API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for retrieving subscriptions in the new v2 API can be found
+             :doc:`here </reference/v2/subscriptions-api/get-subscription>`. For more information on the v2 API, refer
+             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 .. endpoint::
    :method: GET

--- a/source/reference/v1/subscriptions-api/get-subscription.rst
+++ b/source/reference/v1/subscriptions-api/get-subscription.rst
@@ -3,7 +3,6 @@ Get subscription
 .. api-name:: Subscriptions API
    :version: 1
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v1/subscriptions-api/list-subscriptions.rst
+++ b/source/reference/v1/subscriptions-api/list-subscriptions.rst
@@ -11,9 +11,13 @@ List subscriptions
    :api_keys: true
    :oauth: true
 
-.. warning:: This is the documentation of the v1 API. The documentation for listing subscriptions in the new v2 API can
-             be found :doc:`here </reference/v2/subscriptions-api/list-subscriptions>`. For more information on the v2
-             API, refer to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
+
+.. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
+             July 2023. However, new features will only be added to the v2 API.
+
+             The documentation for listing subscriptions in the new v2 API can be found
+             :doc:`here </reference/v2/subscriptions-api/list-subscriptions>`. For more information on the v2 API, refer
+             to our :doc:`v2 migration guide </migrating-v1-to-v2>`.
 
 Retrieve all subscriptions of a customer.
 

--- a/source/reference/v1/subscriptions-api/list-subscriptions.rst
+++ b/source/reference/v1/subscriptions-api/list-subscriptions.rst
@@ -11,7 +11,6 @@ List subscriptions
    :api_keys: true
    :oauth: true
 
-
 .. warning:: The v1 API has been deprecated. The v1 API will be supported for the foreseeable future, at least until
              July 2023. However, new features will only be added to the v2 API.
 

--- a/source/reference/v2/refunds-api/list-refunds.rst
+++ b/source/reference/v2/refunds-api/list-refunds.rst
@@ -7,7 +7,6 @@ List refunds
    :method: GET
    :url: https://api.mollie.com/v2/refunds
 
-
 .. endpoint::
    :method: GET
    :url: https://api.mollie.com/v2/payments/*paymentId*/refunds


### PR DESCRIPTION
This fixes #76. It adds a generic deprecation notice for V1 API endpoints.

TODO:
- No styling has been added yet.
- Currently, warnings have been added manually already. Because I added this deprecation notice, it now shows twice.
- I haven't removed the manual deprecation notice yet, as we may want to adjust the automatic one to be endpoint specific, and contain links to the V2 API documentation, just like the manual notice has right now.