### PR TITLE
Fix endpoint in example

### DIFF
--- a/source/reference/v2/methods-api/list-methods.rst
+++ b/source/reference/v2/methods-api/list-methods.rst
@@ -139,7 +139,7 @@ Request
 .. code-block:: bash
    :linenos:
 
-   curl -X GET https://api.mollie.com/v2/payments/methods \
+   curl -X GET https://api.mollie.com/v2/methods \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
 Response


### PR DESCRIPTION
The endpoint should be https://api.mollie.com/v2/methods, not https://api.mollie.com/v1/payments/methods