### PR TITLE
Fix scrolling issue on mobile devices.

### DIFF
--- a/source/theme/js/mobileNavigationButton.js
+++ b/source/theme/js/mobileNavigationButton.js
@@ -2,6 +2,8 @@ import { debounce } from "lodash";
 import { enhance } from "./utils";
 
 const NO_SCROLL_UTILITY_CLASS = "u-no-scroll";
+const VISIBLE_STATE_CLASS = "is-visible";
+const OPENED_STATE_CLASS = "is-opened";
 const MOBILE_NAV_BREAKPOINT = 980; // _variables.scss:19
 
 export default enhance("mobile-navigation-button", () => {
@@ -10,9 +12,9 @@ export default enhance("mobile-navigation-button", () => {
 
   navigationTrigger.addEventListener("click", event => {
     event.preventDefault();
-    mobileSidebar.classList.toggle("is-visible");
-    navigationTrigger.classList.toggle("is-opened");
-    document.documentElement.classList.toggle("u-no-scroll");
+    mobileSidebar.classList.toggle(VISIBLE_STATE_CLASS);
+    navigationTrigger.classList.toggle(OPENED_STATE_CLASS);
+    document.documentElement.classList.toggle(NO_SCROLL_UTILITY_CLASS);
   });
 
   const allowScrollingOnDesktop = () => {
@@ -26,12 +28,12 @@ export default enhance("mobile-navigation-button", () => {
         // If we're on desktop and the mobile nav was previously opened, close it.
         if (documentWidth > MOBILE_NAV_BREAKPOINT) {
           documentElement.classList.remove(NO_SCROLL_UTILITY_CLASS);
-          mobileSidebar.classList.remove("is-visible");
-          navigationTrigger.classList.remove("is-opened");
+          mobileSidebar.classList.remove(VISIBLE_STATE_CLASS);
+          navigationTrigger.classList.remove(OPENED_STATE_CLASS);
         }
       });
     }
   };
 
-  window.addEventListener("resize", debounce(() => allowScrollingOnDesktop(), 200, false));
+  window.addEventListener("resize", debounce(allowScrollingOnDesktop, 200));
 });

--- a/source/theme/js/mobileNavigationButton.js
+++ b/source/theme/js/mobileNavigationButton.js
@@ -1,4 +1,8 @@
+import { debounce } from "lodash";
 import { enhance } from "./utils";
+
+const NO_SCROLL_UTILITY_CLASS = "u-no-scroll";
+const MOBILE_NAV_BREAKPOINT = 980; // _variables.scss:19
 
 export default enhance("mobile-navigation-button", () => {
   const navigationTrigger = document.querySelector(".js-toggle-mobile-nav");
@@ -10,4 +14,24 @@ export default enhance("mobile-navigation-button", () => {
     navigationTrigger.classList.toggle("is-opened");
     document.documentElement.classList.toggle("u-no-scroll");
   });
+
+  const allowScrollingOnDesktop = () => {
+    const { documentElement } = document;
+    const documentScrollBlocked = documentElement.classList.contains(NO_SCROLL_UTILITY_CLASS);
+
+    if (documentScrollBlocked) {
+      requestAnimationFrame(() => {
+        const documentWidth = window.innerWidth;
+
+        // If we're on desktop and the mobile nav was previously opened, close it.
+        if (documentWidth > MOBILE_NAV_BREAKPOINT) {
+          documentElement.classList.remove(NO_SCROLL_UTILITY_CLASS);
+          mobileSidebar.classList.remove("is-visible");
+          navigationTrigger.classList.remove("is-opened");
+        }
+      });
+    }
+  };
+
+  window.addEventListener("resize", debounce(() => allowScrollingOnDesktop(), 200, false));
 });

--- a/source/theme/js/sidebar.js
+++ b/source/theme/js/sidebar.js
@@ -45,7 +45,6 @@ const scrollToSection = event => {
       document.documentElement.scrollTop = v;
     },
   });
-
 };
 
 const toggleSidebarGroup = event => {

--- a/source/theme/styles/components/_main.scss
+++ b/source/theme/styles/components/_main.scss
@@ -17,6 +17,7 @@
     width: 200px;
     z-index: auto;
     position: relative;
+    display: block;
   }
 
   @media (min-width: breakpoint('extra-large')) {

--- a/source/theme/styles/components/_sidebar.scss
+++ b/source/theme/styles/components/_sidebar.scss
@@ -145,7 +145,7 @@
   background: #666666;
   position: absolute;
   left: 0;
-  top: 8px;
+  top: 4px;
 }
 
 .sidebar__group--collapse > ul {

--- a/source/theme/styles/components/_sidebar.scss
+++ b/source/theme/styles/components/_sidebar.scss
@@ -11,16 +11,14 @@
   height: 100vh;
   overflow-y: auto;
   pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.5s ease;
   padding-left: 50px;
   -webkit-overflow-scrolling: touch;
+  display: none;
 
   @media (min-width: $mobile-navigation-breakpoint) {
     padding-left: 0;
     padding-right: 0;
     position: relative;
-    opacity: 1;
     pointer-events: auto;
     overflow: visible;
     left: auto;
@@ -28,12 +26,13 @@
     right: auto;
     bottom: auto;
     z-index: 0;
+    display: block;
   }
 }
 
 .sidebar.is-visible {
-  opacity: 1;
   pointer-events: all;
+  display: block;
 }
 
 .sidebar__inner {

--- a/source/theme/styles/components/_sidebar.scss
+++ b/source/theme/styles/components/_sidebar.scss
@@ -142,10 +142,10 @@
   content: "";
   height: 1px;
   width: 8px;
-  background: #666666;
+  background: #666;
   position: absolute;
   left: 0;
-  top: 4px;
+  top: 8px;
 }
 
 .sidebar__group--collapse > ul {


### PR DESCRIPTION
Fixes #56.

The mobile menu currently prevents scrolling because it's on top of the main content area. By hiding the entire navigation, scrolling is possible on mobile devices again.