### PR TITLE
Offset HTML anchor to prevent header from overlapping

### DIFF
--- a/source/theme/styles/main.scss
+++ b/source/theme/styles/main.scss
@@ -131,10 +131,16 @@ a.headerlink::before {
 }
 
 .rst-content a:hover,
-.rst-content a:focus, {
+.rst-content a:focus {
   text-decoration: underline;
 }
 
+:target::before {
+  content: "";
+  display: block;
+  height: 130px;
+  margin: -130px 0 0;
+}
 
 /**
  * Typography


### PR DESCRIPTION
This change will make the anchor links always have some offset top and prevent the header from overlapping them. Fixes #64.

Previous behavior:

![image](https://user-images.githubusercontent.com/2484832/40418626-2e8d4d08-5e83-11e8-841b-a67bc7a3884d.png)

Current behavior:

![image](https://user-images.githubusercontent.com/2484832/40418598-1ad20a10-5e83-11e8-876e-0941035c86ff.png)