### PR TITLE
Improve legibility.

### DIFF
--- a/source/theme/styles/components/_main.scss
+++ b/source/theme/styles/components/_main.scss
@@ -54,7 +54,6 @@
 }
 
 .main__content-inner {
-  max-width: 620px;
   width: 100%;
   margin: 0 auto;
 


### PR DESCRIPTION
Fixes #46.

We're currently using a `max-width` for the content area, which makes the sidebar look misaligned. By using the available space within the wrapper, this will be fixed.