### PR TITLE
Add missing locales

### DIFF
--- a/source/changelog/v1/changelog.rst
+++ b/source/changelog/v1/changelog.rst
@@ -8,7 +8,7 @@ June 2018
 
 Friday, 1st
 -----------
-- Added new locales ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` and ``lt_LT`` to the :doc:`Create Customer </reference/v2/customers-api/create-customer>`, :doc:`Create Payment </reference/v2/payments-api/create-payment>`, and :doc:`List Methods </reference/v2/methods-api/list-methods>` endpoints to localize translations and allow for ordering the payment methods in the preferred order for the country.
+- Added new locales ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` and ``lt_LT`` to the :doc:`Create Customer </reference/v1/customers-api/create-customer>`, :doc:`Create Payment </reference/v1/payments-api/create-payment>`, and :doc:`List Methods </reference/v1/methods-api/list-methods>` endpoints to localize translations and allow for ordering the payment methods in the preferred order for the country.
 
 May 2018
 ========

--- a/source/guides/common-data-types.rst
+++ b/source/guides/common-data-types.rst
@@ -90,7 +90,7 @@ A string representing a date and time in `ISO 8601 <https://en.wikipedia.org/wik
 Locale
 ------
 A string representing the country and language in `ISO 15897 <https://en.wikipedia.org/wiki/ISO/IEC_15897>`_ format.
-Possible values: ``de_AT`` ``de_CH`` ``de_DE`` ``en_US`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``.
+Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``.
 
 QR code object
 --------------

--- a/source/reference/v1/customers-api/create-customer.rst
+++ b/source/reference/v1/customers-api/create-customer.rst
@@ -51,7 +51,7 @@ Parameters
        parameter is not provided, the browser language will be used instead in the payment flow (which is usually more
        accurate).
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
    * - | ``metadata``
 

--- a/source/reference/v1/customers-api/get-customer.rst
+++ b/source/reference/v1/customers-api/get-customer.rst
@@ -86,7 +86,7 @@ Response
        not provided when the customer was created, the browser language will be used instead in the payment flow (which
        is usually more accurate).
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
    * - | ``metadata``
 

--- a/source/reference/v1/customers-api/update-customer.rst
+++ b/source/reference/v1/customers-api/update-customer.rst
@@ -50,7 +50,7 @@ Replace ``id`` in the endpoint URL by the customer's ID, for example ``cst_8wmqc
        parameter is not provided, the browser language will be used instead in the payment flow (which is usually more
        accurate).
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
    * - | ``metadata``
 

--- a/source/reference/v1/methods-api/get-method.rst
+++ b/source/reference/v1/methods-api/get-method.rst
@@ -41,7 +41,7 @@ Replace ``id`` in the endpoint URL by the payment method's ID, for example ``cre
 
      - Passing a locale will translate the payment method name to the corresponding language.
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
 Mollie Connect/OAuth parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/reference/v1/payments-api/create-payment.rst
+++ b/source/reference/v1/payments-api/create-payment.rst
@@ -78,7 +78,7 @@ Parameters
        browser language will be used instead if supported by the payment method. You can provide any ISO 15897 locale,
        but our payment screen currently only supports the following languages:
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
    * - | ``method``
 
@@ -166,7 +166,7 @@ Bank transfer
        dedicated bank accounts for Belgium, France, Germany and The Netherlands. Having the customer use a local bank
        account greatly increases the conversion and speed of payment.
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
 Bitcoin
 """""""

--- a/source/reference/v2/customers-api/get-customer.rst
+++ b/source/reference/v2/customers-api/get-customer.rst
@@ -79,7 +79,7 @@ Response
        not provided when the customer was created, the browser language will be used instead in the payment flow (which
        is usually more accurate).
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
    * - | ``metadata``
 

--- a/source/reference/v2/customers-api/update-customer.rst
+++ b/source/reference/v2/customers-api/update-customer.rst
@@ -43,7 +43,7 @@ Replace ``id`` in the endpoint URL by the customer's ID, for example ``cst_8wmqc
        parameter is not provided, the browser language will be used instead in the payment flow (which is usually more
        accurate).
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
    * - | ``metadata``
 

--- a/source/reference/v2/methods-api/get-method.rst
+++ b/source/reference/v2/methods-api/get-method.rst
@@ -32,7 +32,7 @@ Replace ``id`` in the endpoint URL by the methods's ID. For example: ``https://a
 
      - Passing a locale will translate the payment method name in the corresponding language.
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
 Mollie Connect/OAuth parameters
 -------------------------------

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -190,7 +190,7 @@ Bank transfer
        dedicated bank accounts for Belgium, France, Germany and The Netherlands. Having the customer use a local bank
        account greatly increases the conversion and speed of payment.
 
-       Possible values: ``en_US`` ``de_AT`` ``de_CH`` ``de_DE`` ``es_ES`` ``fr_BE`` ``fr_FR`` ``nl_BE`` ``nl_NL``
+       Possible values: ``en_US`` ``nl_NL`` ``nl_BE`` ``fr_FR`` ``fr_BE`` ``de_DE`` ``de_AT`` ``de_CH`` ``es_ES`` ``ca_ES`` ``pt_PT`` ``it_IT`` ``nb_NO`` ``sv_SE`` ``fi_FI`` ``da_DK`` ``is_IS`` ``hu_HU`` ``pl_PL`` ``lv_LV`` ``lt_LT``
 
 Bitcoin
 """""""


### PR DESCRIPTION
- Added the missing locales to all pages where the `locale` parameter is used.
- Link to v1 pages in the v1 changelog