### PR TITLE
`amountRemaining` is of type 'amount object'

### DIFF
--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -180,7 +180,7 @@ Response
 
    * - | ``amountRemaining``
 
-       .. type:: decimal
+       .. type:: amount object
 
      - The remaining amount that can be refunded. Only available when refunds are available for this payment.
 


### PR DESCRIPTION
`amountRemaining` should have the same data type as `amountRefunded` and `amount`.