### PR TITLE
Make gtm.js during html-production step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ html: Makefile source/_static/style.css source/_static/index.js source/_static/g
 html-only:
 	@${SPHINXBUILD} -M html "${SOURCEDIR}" "${BUILDDIR}" ${SPHINXOPTS} ${O}
 
-html-production: Makefile source/_static/style.css source/_static/index.js verify
+html-production: Makefile source/_static/style.css source/_static/index.js source/_static/gtm.js verify
 	@${SPHINXBUILD} -M html "${SOURCEDIR}" "${BUILDDIR}" ${SPHINXOPTS} ${SPHINXPRODOPTS} ${O}


### PR DESCRIPTION
The `make-gtm` make step doesn't get called when Travis deploys a new build. By adding it to `make html-production`, this will be fixed and `gtm.js` will be published on production.