### PR TITLE
Use capital EPS instead of eps.

### DIFF
--- a/source/changelog/v1/changelog.rst
+++ b/source/changelog/v1/changelog.rst
@@ -10,7 +10,7 @@ June 2018
 Monday, 25th
 ------------
 
-- Added the new payment methods Giropay (``giropay``) and eps (``eps``). Note that this method may not be available on
+- Added the new payment methods Giropay (``giropay``) and EPS (``eps``). Note that this method may not be available on
   your account straight away. If it is not, contact our support department to get it activated for your account.
 
 - Passing a payment description in the form of ``Order <order number>`` will now pass the order number to PayPal in the

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -10,7 +10,7 @@ June 2018
 Monday, 25th
 ------------
 
-- Added the new payment methods Giropay (``giropay``) and eps (``eps``). Note that this method may not be available on
+- Added the new payment methods Giropay (``giropay``) and EPS (``eps``). Note that this method may not be available on
   your account straight away. If it is not, contact our support department to get it activated for your account.
 
 - Passing a payment description in the form of ``Order <order number>`` will now pass the order number to PayPal in the

--- a/source/guides/payment-status-changes.rst
+++ b/source/guides/payment-status-changes.rst
@@ -64,7 +64,7 @@ Expiry times per payment method
 +---------------------------+-----------------------------------+
 | - Bancontact              | 1 hour                            |
 | - Bitcoin                 |                                   |
-| - eps                     |                                   |
+| - EPS                     |                                   |
 | - Giropay                 |                                   |
 | - KBC                     |                                   |
 | - SOFORT Banking          |                                   |

--- a/source/index.rst
+++ b/source/index.rst
@@ -33,7 +33,7 @@ Mollie is always adding new payment methods. The Mollie API currently supports t
 * `Bitcoin <https://www.mollie.com/en/payments/bitcoin>`_
 * `Credit card <https://www.mollie.com/en/payments/credit-card>`_ (VISA, MasterCard, Maestro and American Express)
 * `SEPA Direct Debit <https://www.mollie.com/en/payments/direct-debit>`_
-* `eps <https://www.mollie.com/en/payments/eps>`_
+* `EPS <https://www.mollie.com/en/payments/eps>`_
 * `Gift cards <https://www.mollie.com/en/payments/gift-cards>`_ (Webshop Giftcard, Podium Cadeaukaart, VVV Cadeaukaart,
   YourGift etc.)
 * `Giropay <https://www.mollie.com/en/payments/giropay>`_

--- a/source/reference/v1/payments-api/get-payment.rst
+++ b/source/reference/v1/payments-api/get-payment.rst
@@ -584,7 +584,7 @@ Credit card
 
               Possible values: ``intra-eu`` ``other``
 
-eps
+EPS
 """
 .. list-table::
    :widths: auto


### PR DESCRIPTION
We're using capitalized `EPS` on the marketing website instead of lowercase `eps`.