### PR TITLE
Fix permissions. Remove recentlyUsedMethods from example response.

### DIFF
--- a/source/reference/v2/customers-api/get-customer.rst
+++ b/source/reference/v2/customers-api/get-customer.rst
@@ -166,10 +166,6 @@ Response
        "email": "customer@example.org",
        "locale": "nl_NL",
        "metadata": null,
-       "recentlyUsedMethods": [
-           "creditcard",
-           "ideal"
-       ],
        "createdAt": "2018-04-06T13:23:21.0Z",
        "_links": {
            "self": {

--- a/source/reference/v2/permissions-api/get-permission.rst
+++ b/source/reference/v2/permissions-api/get-permission.rst
@@ -40,7 +40,7 @@ Response
      - The permission's unique identifier, for example ``payments.read``. See
        :doc:`Permissions </oauth/permissions>` for details about the available permissions.
 
-       Possible values: ``apikeys.read`` ``apikeys.write`` ``customers.read`` ``customers.write`` ``mandates.read``
+       Possible values: ``customers.read`` ``customers.write`` ``invoices.read`` ``mandates.read``
        ``mandates.write`` ``organizations.read`` ``organizations.write`` ``payments.read`` ``payments.write``
        ``profiles.read`` ``profiles.write`` ``refunds.read`` ``refunds.write`` ``settlements.read``
 


### PR DESCRIPTION
- Add the invoices.* permission to “get permission”
- Remove the apiKeys.* permission from “get permission”
- Remove recentlyUsedMethods from the example response in “get customer”