### PR TITLE
Php examples for Payment, Method and (partial) Refund resource

### DIFF
--- a/source/reference/v2/methods-api/get-method.rst
+++ b/source/reference/v2/methods-api/get-method.rst
@@ -140,13 +140,23 @@ Response
 Example
 -------
 
-Request
-^^^^^^^
+Request (curl)
+^^^^^^^^^^^^^^
 .. code-block:: bash
    :linenos:
 
    curl -X GET https://api.mollie.com/v2/methods/ideal?include=issuers \
        -H "Authorization: Bearer live_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+    <?php
+    $mollie = new \Mollie\Api\MollieApiClient();
+    $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+    $mollie->methods->get("ideal", ["include" => "issuers"]);
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/methods-api/list-methods.rst
+++ b/source/reference/v2/methods-api/list-methods.rst
@@ -21,7 +21,7 @@ When using the ``first`` sequence type, methods will be returned if they can be 
 sequence and if they are enabled in the Dashboard.
 
 When using the ``recurring`` sequence type, methods that can be used for recurring payments or subscriptions will be
-returned. Enabling / disabling methods in the dashboard does not affect how they can be used for recurring payments. 
+returned. Enabling / disabling methods in the dashboard does not affect how they can be used for recurring payments.
 
 Parameters
 ----------
@@ -146,13 +146,23 @@ Response
 Example
 -------
 
-Request
-^^^^^^^
+Request (curl)
+^^^^^^^^^^^^^^
 .. code-block:: bash
    :linenos:
 
    curl -X GET https://api.mollie.com/v2/methods \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+    <?php
+    $mollie = new \Mollie\Api\MollieApiClient();
+    $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+    $methods = $mollie->methods->all();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/cancel-payment.rst
+++ b/source/reference/v2/payments-api/cancel-payment.rst
@@ -30,13 +30,23 @@ A payment object is returned, as described in :doc:`Get payment </reference/v2/p
 Example
 -------
 
-Request
-^^^^^^^
+Request (curl)
+^^^^^^^^^^^^^^
 .. code-block:: bash
    :linenos:
 
    curl -X DELETE https://api.mollie.com/v2/payments/tr_WDqYK6vllg \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+    <?php
+    $mollie = new \Mollie\Api\MollieApiClient();
+    $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+    $canceled_payment = $mollie->payments->delete("tr_WDqYK6vllg");
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -1107,13 +1107,23 @@ For an implemention guide, see our :doc:`QR codes guide </guides/qr-codes>`.
 Example
 -------
 
-Request
-^^^^^^^
+Request (curl)
+^^^^^^^^^^^^^^
 .. code-block:: bash
    :linenos:
 
    curl -X GET https://api.mollie.com/v2/payments/tr_WDqYK6vllg \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+    <?php
+    $mollie = new \Mollie\Api\MollieApiClient();
+    $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+    $payment = $mollie->payments->get("tr_WDqYK6vllg");
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/list-payments.rst
+++ b/source/reference/v2/payments-api/list-payments.rst
@@ -143,13 +143,28 @@ Response
 Example
 -------
 
-Request
-^^^^^^^
+Request (curl)
+^^^^^^^^^^^^^^
 .. code-block:: bash
    :linenos:
 
    curl -X GET https://api.mollie.com/v2/payments?limit=5 \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+    <?php
+    $mollie = new \Mollie\Api\MollieApiClient();
+    $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+    // get the first page
+    $payments = $mollie->payments->page();
+
+    // get the next page
+    $next_payments = $payments->next();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/create-refund.rst
+++ b/source/reference/v2/refunds-api/create-refund.rst
@@ -107,8 +107,8 @@ A refund object is returned, as described in :doc:`Get refund </reference/v2/ref
 Example
 -------
 
-Request
-^^^^^^^
+Request (curl)
+^^^^^^^^^^^^^^
 .. code-block:: bash
    :linenos:
 
@@ -116,6 +116,23 @@ Request
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM" \
        -d "amount[currency]=EUR" \
        -d "amount[value]=5.95"
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+    <?php
+    $mollie = new \Mollie\Api\MollieApiClient();
+    $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+    $payment = $mollie->payments->get("tr_WDqYK6vllg");
+    $refund = $payment->refund([
+      "amount" => [
+        "currency" => "EUR",
+        "value" => "5.95" // You must send the correct number of decimals, thus we enforce the use of strings
+      ]
+    ]);
 
 Response
 ^^^^^^^^


### PR DESCRIPTION
Added php examples for Payment resource:
- cancel
- get
- list

Added php examples for Method resource:
- list
- get (including issuers)

Added php example for Refund resource:
- create

(Struggling a bit with the Refund `get` method, will add later on.)