### PR TITLE
Orders and Shipments php examples. Incl refunds

### DIFF
--- a/source/reference/v2/orders-api/cancel-order-line.rst
+++ b/source/reference/v2/orders-api/cancel-order-line.rst
@@ -42,6 +42,19 @@ Request (curl)
    curl -X DELETE https://api.mollie.com/v2/orders/ord_8wmqcHMN4U/lines/odl_dgtxyl \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+     $order = $mollie->orders->get("ord_8wmqcHMN4U");
+     $order->cancelLine("odl_dgtxyl");
+     $updatedOrder = $mollie->orders->get($order->id);
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -46,6 +46,16 @@ Request (curl)
    curl -X DELETE https://api.mollie.com/v2/orders/ord_8wmqcHMN4U \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+     $order = $mollie->orders->cancel("ord_8wmqcHMN4U");
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/create-order-refund.rst
+++ b/source/reference/v2/orders-api/create-order-refund.rst
@@ -97,3 +97,26 @@ Request (curl)
             ],
             "description": "Required quantity not in stock, refunding one photo book."
        }'
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+     $order = $mollie->orders->get("ord_stTC2WHAuS");
+     $order->refund([
+        'lines' => [
+            'id' => 'odl_dgtxyl',
+            'quantity' => 1,
+        ],
+        "description": "Required quantity not in stock, refunding one photo book.",
+    ]);
+
+    // Alternative shorthand for refunding all eligible order lines
+    $order->refundAll([
+      "description": "Required quantity not in stock, refunding one photo book.",
+    ]);

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -482,3 +482,101 @@ Request (curl)
                 }
             ]
         }'
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+     $order = $mollie->orders->create([
+       "amount" => [
+         "value" => "1027.99",
+         "currency" => "EUR"
+       ],
+       "billingAddress" => [
+         "streetAndNumber" => "Keizersgracht 313",
+         "city" => "Amsterdam",
+         "region" => "Noord-Holland",
+         "postalCode" => "1234AB",
+         "country" => "NL",
+         "title" => "Dhr.",
+         "givenName" => "Adriaan",
+         "familyName" => "Mol",
+         "email" => "adriaan@mollie.com",
+         "phone" => "+31309202070",
+       ],
+       "shippingAddress" => [
+         "streetAndNumber" => "Keizersgracht 313",
+         "streetAdditional" => "4th floor",
+         "city" => "Haarlem",
+         "region" => "Noord-Holland",
+         "postalCode" => "5678AB",
+         "country" => "NL",
+         "title" => "Mr.",
+         "givenName" => "Chuck",
+         "familyName" => "Norris",
+         "email" => "norris@chucknorrisfacts.net",
+       ],
+       "metadata" => [
+         "order_id" => "1337",
+         "description" => "Lego cars"
+       ],
+       "consumerDateOfBirth" => "1958-01-31",
+       "locale" => "nl_NL",
+       "orderNumber" => "1337",
+       "redirectUrl" => "https://example.org/redirect",
+       "webhookUrl" => "https://example.org/webhook",
+       "method" => "klarnapaylater",
+       "lines" => [
+         [
+           "type" => "physical",
+           "sku" => "5702016116977",
+           "name" => "LEGO 42083 Bugatti Chiron",
+           "productUrl" => "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+           "imageUrl" => 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
+           "quantity" => 2,
+           "vatRate" => "21.00",
+           "unitPrice" => [
+             "currency" => "EUR",
+             "value" => "399.00"
+           ],
+           "totalAmount" => [
+             "currency" => "EUR",
+             "value" => "698.00"
+           ],
+           "discountAmount" => [
+             "currency" => "EUR",
+             "value" => "100.00"
+           ],
+           "vatAmount" => [
+             "currency" => "EUR",
+             "value" => "121.14"
+           ]
+         ],
+         [
+           "type" => "physical",
+           "sku" => "5702015594028",
+           "name" => "LEGO 42056 Porsche 911 GT3 RS",
+           "productUrl" => "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+           "imageUrl" => 'https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$',
+           "quantity" => 1,
+           "vatRate" => "21.00",
+           "unitPrice" => [
+             "currency" => "EUR",
+             "value" => "329.99"
+           ],
+           "totalAmount" => [
+             "currency" => "EUR",
+             "value" => "329.99"
+           ],
+           "vatAmount" => [
+             "currency" => "EUR",
+             "value" => "57.27"
+           ]
+         ]
+       ]
+   ]);

--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -401,6 +401,16 @@ Request (curl)
 
 .. _get-order-response:
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+     $order = $mollie->orders->get("ord_kEn1PlbGa");
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/list-order-refunds.rst
+++ b/source/reference/v2/orders-api/list-order-refunds.rst
@@ -121,6 +121,18 @@ Request (curl)
    curl -X GET https://api.mollie.com/v2/orders/ord_pbjz8x/refunds \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+     $order = $mollie->orders->get("ord_stTC2WHAuS");
+     $refunds = $order->refunds();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/list-orders.rst
+++ b/source/reference/v2/orders-api/list-orders.rst
@@ -139,6 +139,18 @@ Request (curl)
    curl -X GET https://api.mollie.com/v2/orders \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+     $most_recent_orders = $mollie->orders->page();
+     $previous_orders = $most_recent_orders->next();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/shipments-api/create-shipment.rst
+++ b/source/reference/v2/shipments-api/create-shipment.rst
@@ -52,7 +52,7 @@ Parameters
             - The number of items that should be shipped for this order line. When this parameter is omitted, the
               whole order line will be shipped.
 
-              Must be less than the number of items already shipped for this order line. 
+              Must be less than the number of items already shipped for this order line.
 
               .. note:: At the moment, it is not possible to partially ship an order line if it has a discount.
 
@@ -135,3 +135,44 @@ Request (curl)
                 "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C"
             },
         }'
+
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM');
+
+     $order = $mollie->orders->get('ord_kEn1PlbGa');
+     $shipment = $order->createShipment(
+        [
+          'lines' => [
+            [
+              'id' => 'odl_dgtxyl',
+              'quantity' => 1, // you can set the quantity if not all is shipped at once
+            ],
+            [
+              'id' => 'odl_jp31jz',
+              // assume all is shipped if no quantity is specified
+            ],
+          ],
+          [
+            'tracking' => [
+              'carrier' => 'PostNL',
+              'code' => '3SKABA000000000',
+              'url' => 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
+            ],
+          ],
+        ]
+    );
+
+    // Alternative shorthand for shipping all remaining order lines
+    $shipment = $order->shipAll([
+      'tracking' => [
+        'carrier' => 'PostNL',
+        'code' => '3SKABA000000000',
+        'url' => 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
+      ],
+    ]);

--- a/source/reference/v2/shipments-api/get-shipment.rst
+++ b/source/reference/v2/shipments-api/get-shipment.rst
@@ -144,6 +144,18 @@ Request (curl)
    curl -X GET https://api.mollie.com/v2/orders/ord_kEn1PlbGa/shipments/shp_3wmsgCJN4U \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM');
+
+     $order = $mollie->orders->get('ord_kEn1PlbGa');
+     $shipment = $order->getShipment("shp_3wmsgCJN4U");
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/shipments-api/list-shipments.rst
+++ b/source/reference/v2/shipments-api/list-shipments.rst
@@ -99,6 +99,18 @@ Request (curl)
    curl -X GET https://api.mollie.com/v2/order/ord_kEn1PlbGa/shipments \
        -H "Authorization: Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+Request (PHP)
+^^^^^^^^^^^^^
+.. code-block:: php
+   :linenos:
+
+     <?php
+     $mollie = new \Mollie\Api\MollieApiClient();
+     $mollie->setApiKey('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM');
+
+     $order = $mollie->orders->get('ord_kEn1PlbGa');
+     $shipments = $order->shipments();
+
 Response
 ^^^^^^^^
 .. code-block:: http


### PR DESCRIPTION
This is for the upcoming [mollie/mollie-api-php client](https://github.com/mollie/mollie-api-php) release supporting the Orders and Shipments API.

~~~Order refunds examples are not yet included.~~~ Now includes order refunds.

Relates to:
- #124 
- https://github.com/mollie/mollie-api-php/pull/252
- https://github.com/mollie/mollie-api-php/issues/247