### PR TITLE
Update Orders API documentation to include quantity & amount properties

### DIFF
--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -119,6 +119,21 @@ Response
                 "status": "canceled",
                 "isCancelable": false,
                 "quantity": 2,
+                "quantityShipped": 0,
+                "amountShipped": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityRefunded": 0,
+                "amountRefunded": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityCanceled": 2,
+                "amountCanceled": {
+                    "value": "698.00",
+                    "currency": "EUR"
+                },
                 "unitPrice": {
                     "value": "399.00",
                     "currency": "EUR"
@@ -156,6 +171,21 @@ Response
                 "status": "canceled",
                 "isCancelable": false,
                 "quantity": 1,
+                "quantityShipped": 0,
+                "amountShipped": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityRefunded": 0,
+                "amountRefunded": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityCanceled": 1,
+                "amountCanceled": {
+                    "value": "329.99",
+                    "currency": "EUR"
+                },
                 "unitPrice": {
                     "value": "329.99",
                     "currency": "EUR"

--- a/source/reference/v2/orders-api/create-order-refund.rst
+++ b/source/reference/v2/orders-api/create-order-refund.rst
@@ -120,3 +120,75 @@ Request (PHP)
     $order->refundAll([
       "description": "Required quantity not in stock, refunding one photo book.",
     ]);
+
+Response
+^^^^^^^^
+.. code-block:: http
+   :linenos:
+
+   HTTP/1.1 201 Created
+   Content-Type: application/hal+json; charset=utf-8
+
+   {
+       "resource": "refund",
+       "id": "re_4qqhO89gsT",
+       "amount": {
+           "currency": "EUR",
+           "value": "698.00"
+       },
+       "status": "pending",
+       "createdAt": "2018-03-14T17:09:02.0Z",
+       "description": "Required quantity not in stock, refunding one photo book.",
+       "paymentId": "tr_WDqYK6vllg",
+       "orderId": "ord_stTC2WHAuS",
+       "lines": [
+           {
+               "resource": "orderline",
+               "id": "odl_dgtxyl",
+               "orderId": "ord_stTC2WHAuS",
+               "name": "LEGO 42083 Bugatti Chiron",
+               "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+               "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+               "sku": "5702016116977",
+               "type": "physical",
+               "status": "refunded",
+               "quantity": 2,
+               "unitPrice": {
+                   "value": "399.00",
+                   "currency": "EUR"
+               },
+               "vatRate": "21.00",
+               "vatAmount": {
+                   "value": "121.14",
+                   "currency": "EUR"
+               },
+               "discountAmount": {
+                   "value": "100.00",
+                   "currency": "EUR"
+               },
+               "totalAmount": {
+                   "value": "698.00",
+                   "currency": "EUR"
+               },
+               "createdAt": "2018-08-02T09:29:56+00:00"
+           }
+       ],
+       "_links": {
+           "self": {
+               "href": "https://api.mollie.com/v2/payments/tr_WDqYK6vllg/refunds/re_4qqhO89gsT",
+               "type": "application/hal+json"
+           },
+           "payment": {
+               "href": "https://api.mollie.com/v2/payments/tr_WDqYK6vllg",
+               "type": "application/hal+json"
+           },
+           "order": {
+               "href": "https://api.mollie.com/v2/orders/ord_stTC2WHAuS",
+               "type": "application/hal+json"
+           },
+           "documentation": {
+               "href": "https://docs.mollie.com/reference/v2/orders-api/create-order-refund",
+               "type": "text/html"
+           }
+       }
+   }

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -243,7 +243,7 @@ The order lines contain the actual things that your customer bought.
 
        For example: ``{"currency":"EUR", "value":"35.00"}`` if the VAT amount of this order line is €35.00.
 
-       The ``vatAmount`` should match the following formula: ``totalAmount × (vatRate / 100)``
+       The ``vatAmount`` should match the following formula: ``totalAmount × (vatRate / (100 + vatRate))``
 
    * - ``sku``
 
@@ -594,7 +594,7 @@ Response
 .. code-block:: http
    :linenos:
 
-   HTTP/1.1 200 OK
+   HTTP/1.1 201 Created
    Content-Type: application/hal+json; charset=utf-8
 
    {
@@ -662,6 +662,21 @@ Response
                "status": "created",
                "isCancelable": true,
                "quantity": 2,
+               "quantityShipped": 0,
+               "amountShipped": {
+                   "value": "0.00",
+                   "currency": "EUR"
+               },
+               "quantityRefunded": 0,
+               "amountRefunded": {
+                   "value": "0.00",
+                   "currency": "EUR"
+               },
+               "quantityCanceled": 0,
+               "amountCanceled": {
+                   "value": "0.00",
+                   "currency": "EUR"
+               },
                "unitPrice": {
                    "value": "399.00",
                    "currency": "EUR"
@@ -693,6 +708,21 @@ Response
                "status": "created",
                "isCancelable": true,
                "quantity": 1,
+               "quantityShipped": 0,
+               "amountShipped": {
+                   "value": "0.00",
+                   "currency": "EUR"
+               },
+               "quantityRefunded": 0,
+               "amountRefunded": {
+                   "value": "0.00",
+                   "currency": "EUR"
+               },
+               "quantityCanceled": 0,
+               "amountCanceled": {
+                   "value": "0.00",
+                   "currency": "EUR"
+               },
                "unitPrice": {
                    "value": "329.99",
                    "currency": "EUR"

--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -341,7 +341,7 @@ The order lines contain the actual things the your customer bought.
 
        .. type:: int
 
-     - The number items that are shipped for this order line.
+     - The number of items that are shipped for this order line.
 
    * - ``amountShipped``
 
@@ -353,7 +353,7 @@ The order lines contain the actual things the your customer bought.
 
        .. type:: int
 
-     - The number items that are refunded for this order line.
+     - The number of items that are refunded for this order line.
 
    * - ``amountRefunded``
 
@@ -365,7 +365,7 @@ The order lines contain the actual things the your customer bought.
 
        .. type:: int
 
-     - The number items that are canceled in this order line.
+     - The number of items that are canceled in this order line.
 
    * - ``amountCanceled``
 
@@ -568,6 +568,21 @@ Response
                 "status": "created",
                 "isCancelable": true,
                 "quantity": 2,
+                "quantityShipped": 0,
+                "amountShipped": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityRefunded": 0,
+                "amountRefunded": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityCanceled": 0,
+                "amountCanceled": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
                 "unitPrice": {
                     "value": "399.00",
                     "currency": "EUR"
@@ -599,6 +614,21 @@ Response
                 "status": "created",
                 "isCancelable": true,
                 "quantity": 1,
+                "quantityShipped": 0,
+                "amountShipped": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityRefunded": 0,
+                "amountRefunded": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityCanceled": 0,
+                "amountCanceled": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
                 "unitPrice": {
                     "value": "329.99",
                     "currency": "EUR"

--- a/source/reference/v2/orders-api/list-order-refunds.rst
+++ b/source/reference/v2/orders-api/list-order-refunds.rst
@@ -154,14 +154,14 @@ Response
                    },
                    "status": "processing",
                    "createdAt": "2018-03-14T17:09:02.0Z",
-                   "description": "Item not in stock, refunding",
+                   "description": "Required quantity not in stock, refunding one photo book.",
                    "paymentId": "tr_WDqYK6vllg",
-                   "orderId": "ord_pbjz8x",
+                   "orderId": "ord_stTC2WHAuS",
                    "lines": [
                        {
                            "resource": "orderline",
                            "id": "odl_dgtxyl",
-                           "orderId": "ord_pbjz8x",
+                           "orderId": "ord_stTC2WHAuS",
                            "name": "LEGO 42083 Bugatti Chiron",
                            "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
                            "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
@@ -199,7 +199,7 @@ Response
                            "type": "application/hal+json"
                        },
                        "order": {
-                           "href": "https://api.mollie.com/v2/orders/ord_pbjz8x",
+                           "href": "https://api.mollie.com/v2/orders/ord_stTC2WHAuS",
                            "type": "application/hal+json"
                        },
                        "documentation": {

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -182,6 +182,21 @@ Response
                 "status": "created",
                 "isCancelable": true,
                 "quantity": 2,
+                "quantityShipped": 0,
+                "amountShipped": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityRefunded": 0,
+                "amountRefunded": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityCanceled": 0,
+                "amountCanceled": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
                 "unitPrice": {
                     "value": "399.00",
                     "currency": "EUR"
@@ -213,6 +228,21 @@ Response
                 "status": "created",
                 "isCancelable": true,
                 "quantity": 1,
+                "quantityShipped": 0,
+                "amountShipped": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityRefunded": 0,
+                "amountRefunded": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
+                "quantityCanceled": 0,
+                "amountCanceled": {
+                    "value": "0.00",
+                    "currency": "EUR"
+                },
                 "unitPrice": {
                     "value": "329.99",
                     "currency": "EUR"

--- a/source/reference/v2/subscriptions-api/cancel-subscription.rst
+++ b/source/reference/v2/subscriptions-api/cancel-subscription.rst
@@ -20,7 +20,10 @@ example: ``/v2/customers/cst_stTC2WHAuS/subscriptions/sub_rVKGtNd6s3``.
 
 Response
 --------
-``200 Ok``
+``200`` ``application/hal+json; charset=utf-8``
+
+A subscription object is returned, as described in
+:doc:`Get subscription </reference/v2/subscriptions-api/get-subscription>`.
 
 Example
 -------


### PR DESCRIPTION
- Added shipping, refunding and cancelation quantity and amount properties to all Orders API endpoints that need it. Futhermore, modified some examples to make them more consistent with each other.
- Boyscouted some missing documentation for the cancel subscription endpoint.
- Fixed a mistake in the formula for calculating the `vatAmount` for an order line.