### PR TITLE
Update examples to reflect the docs

### DIFF
--- a/source/reference/v2/settlements-api/get-settlement.rst
+++ b/source/reference/v2/settlements-api/get-settlement.rst
@@ -314,8 +314,8 @@ Response
        "resource": "settlement",
        "id": "stl_jDk30akdN",
        "reference": "1234567.1804.03",
-       "createdDatetime": "2018-04-06T06:00:01.0Z",
-       "settledDatetime": "2018-04-06T09:41:44.0Z",
+       "createdAt": "2018-04-06T06:00:01.0Z",
+       "settledAt": "2018-04-06T09:41:44.0Z",
        "amount": {
            "currency": "EUR",
            "value": "39.75"

--- a/source/reference/v2/settlements-api/list-settlements.rst
+++ b/source/reference/v2/settlements-api/list-settlements.rst
@@ -135,8 +135,8 @@ Response
                    "resource": "settlement",
                    "id": "stl_jDk30akdN",
                    "reference": "1234567.1804.03",
-                   "createdDatetime": "2018-04-06T06:00:01.0Z",
-                   "settledDatetime": "2018-04-06T09:41:44.0Z",
+                   "createdAt": "2018-04-06T06:00:01.0Z",
+                   "settledAt": "2018-04-06T09:41:44.0Z",
                    "amount": {
                        "currency": "EUR",
                        "value": "39.75"


### PR DESCRIPTION
According to the docs the fields `createdDatetime` and `settledDateTime`
have been renamed to `createdAt` and `settledAt`.