### PR TITLE
A number of improvements to the Orders API documentation

### DIFF
--- a/source/orders/status-changes.rst
+++ b/source/orders/status-changes.rst
@@ -50,7 +50,7 @@ The following diagram shows how one order status leads to another:
     that does not support authorizations.
 
     * Mollie will call your webhook when the order reaches this state.
-    * Order lines can be in the state ``paid``.
+    * All order lines will also be in the ``paid`` state.
     * Can transition to: ``shipping`` and ``completed``.
 
 .. _order-status-pending:
@@ -81,23 +81,24 @@ The following diagram shows how one order status leads to another:
 
 ``shipping``
 ^^^^^^^^^^^^
-    The order will move into this state when you start shipping your first order lines. When the order is in this state,
-    it means that you still have some order lines that are not shipped yet.
+    The order will move into this state when you start shipping your first order line or part of an order line. When
+    the order is in this state, it means that you still have some order lines that are not shipped yet.
 
     * This is not a status Mollie will call your webhook for.
     * Order lines can be in the states ``paid``, ``authorized``, ``shipping``, ``completed`` or ``canceled``.
-      At least one line should be in ``paid`` or ``authorized`` and at least one other line should be ``completed``.
+      At least one line should be in ``paid`` or ``authorized`` and at least one other line should be ``shipping``
+      or ``completed``.
     * Can transition to: ``completed``.
 
 .. _order-status-completed:
 
 ``completed``
 ^^^^^^^^^^^^^
-    When all order lines are shipped or canceled, the order will be set to this status. At least one line should be
-    shipped. If all lines are canceled, the status of the order will change to ``canceled`` instead.
+    When all order lines are completed or canceled, the order will be set to this status. At least one line should be
+    completed. If all lines are canceled, the status of the order will change to ``canceled`` instead.
 
     * Mollie will call your webhook when the order reaches this state.
-    * Order lines can be in the states ``completed`` or ``canceled``. At least one line should be ``completed``.
+    * Order lines can be in the state ``completed`` or ``canceled``. At least one line should be ``completed``.
     * This is a final state, the order can't transition to another state.
 
 .. _order-status-canceled:
@@ -115,8 +116,11 @@ The following diagram shows how one order status leads to another:
 
 ``expired``
 ^^^^^^^^^^^
-    The order will expire when an order is not shipped in time after an authorization. This is currently 28 days but
-    might change in the future.
+    By default, the expiry period of an order is 28 days. If no payment is initiated for an order within the given
+    expiry period, the order will expire. When an order is paid using a payment method that supports authorizations,
+    the order has to be *completed* within the given expiry period.
+
+    *Please note*: the default expiry period of 28 days might change in the future.
 
     * Mollie will call your webhook when the order reaches this state.
     * All order lines will be ``canceled``.
@@ -136,12 +140,13 @@ The following diagram shows how one order line status leads to another:
 
     * The order has status ``created`` or ``pending``.
     * Can transition to: ``paid``, ``authorized`` and ``canceled``.
+    * Only the whole order can be canceled at this point in time, not individual order lines.
 
 .. _orderline-status-paid:
 
 ``paid``
 ^^^^^^^^
-    The order line status will be set to this status when the order's payment is successfully completed with a payment
+    The order line will be set to this status when the order's payment is successfully completed with a payment
     method that does not support authorizations.
 
     * The order has status ``paid`` or ``shipping``.
@@ -173,7 +178,7 @@ The following diagram shows how one order line status leads to another:
 ``completed``
 ^^^^^^^^^^^^^
     When the order line is completely shipped, it will get this status. The order line will also get this status when it
-    is partially shipped and the rest of the line is ``canceled``.
+    is e.g. partially shipped or refunded and the rest of the line is ``canceled``.
 
     * The order has status ``shipping`` or ``completed``.
     * This is a final state, the order line can't transition to another state.

--- a/source/orders/status-changes.rst
+++ b/source/orders/status-changes.rst
@@ -85,9 +85,9 @@ The following diagram shows how one order status leads to another:
     the order is in this state, it means that you still have some order lines that are not shipped yet.
 
     * This is not a status Mollie will call your webhook for.
-    * Order lines can be in the states ``paid``, ``authorized``, ``shipping``, ``completed`` or ``canceled``.
-      At least one line should be in ``paid`` or ``authorized`` and at least one other line should be ``shipping``
-      or ``completed``.
+    * Order lines can be in the states ``paid``, ``authorized``, ``shipping``, ``completed`` or ``canceled``. At
+      least one line should be in state ``paid`` or ``authorized`` and at least one other line should be in state
+      ``shipping`` or ``completed``.
     * Can transition to: ``completed``.
 
 .. _order-status-completed:
@@ -178,7 +178,7 @@ The following diagram shows how one order line status leads to another:
 ``completed``
 ^^^^^^^^^^^^^
     When the order line is completely shipped, it will get this status. The order line will also get this status when it
-    is e.g. partially shipped or refunded and the rest of the line is ``canceled``.
+    is partially shipped and the rest of the line is ``canceled``.
 
     * The order has status ``shipping`` or ``completed``.
     * This is a final state, the order line can't transition to another state.

--- a/source/reference/v2/captures-api/get-capture.rst
+++ b/source/reference/v2/captures-api/get-capture.rst
@@ -110,7 +110,7 @@ Response
 
        .. type:: object
 
-     - An object with several URL objects relevant to the customer. Every URL object will contain an ``href`` and a
+     - An object with several URL objects relevant to the capture. Every URL object will contain an ``href`` and a
        ``type`` field.
 
        .. list-table::

--- a/source/reference/v2/orders-api/cancel-order-lines.rst
+++ b/source/reference/v2/orders-api/cancel-order-lines.rst
@@ -18,8 +18,9 @@ Cancel order lines
 This endpoint can be used to cancel a single or multiple order lines. Use
 :doc:`cancel order </reference/v2/orders-api/cancel-order>` when you want to cancel the entire order.
 
-An order line can only be canceled while its ``status`` field is either ``created`` or ``authorized``. You should
-cancel an order line if you don't intend to ship it.
+An order line can only be canceled while its ``status`` field is either ``authorized`` or ``shipping``. If you cancel
+an ``authorized`` order line, the new order line status will be ``canceled``. Canceling a ``shipping`` order line will
+result in a ``completed`` order line status. You should cancel an order line if you don't intend to (fully) ship it.
 
 If the order line is ``paid`` or already ``completed``, you should create a refund for that line instead.
 

--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -74,14 +74,6 @@ Response
             "value": "1027.99",
             "currency": "EUR"
         },
-        "amountCaptured": {
-            "value": "0.00",
-            "currency": "EUR"
-        },
-        "amountRefunded": {
-            "value": "0.00",
-            "currency": "EUR"
-        },
         "status": "canceled",
         "isCancelable": false,
         "metadata": null,
@@ -89,7 +81,6 @@ Response
         "expiresAt": "2018-08-30T09:29:56+00:00",
         "mode": "live",
         "locale": "nl_NL",
-        "orderNumber": "18475",
         "billingAddress": {
             "streetAndNumber": "Keizersgracht 313",
             "postalCode": "1016 EE",
@@ -99,6 +90,7 @@ Response
             "familyName": "Skywalker",
             "email": "luke@skywalker.com"
         },
+        "orderNumber": "18475",
         "shippingAddress": {
             "streetAndNumber": "Keizersgracht 313",
             "postalCode": "1016 EE",
@@ -108,14 +100,13 @@ Response
             "familyName": "Skywalker",
             "email": "luke@skywalker.com"
         },
+        "redirectUrl": "https://example.org/redirect",
         "lines": [
             {
                 "resource": "orderline",
                 "id": "odl_dgtxyl",
                 "orderId": "ord_pbjz8x",
                 "name": "LEGO 42083 Bugatti Chiron",
-                "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
-                "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
                 "sku": "5702016116977",
                 "type": "physical",
                 "status": "canceled",
@@ -136,6 +127,9 @@ Response
                     "value": "698.00",
                     "currency": "EUR"
                 },
+                "shippableQuantity": 0,
+                "refundableQuantity": 0,
+                "cancelableQuantity": 0,
                 "unitPrice": {
                     "value": "399.00",
                     "currency": "EUR"
@@ -155,9 +149,13 @@ Response
                 },
                 "createdAt": "2018-08-02T09:29:56+00:00",
                 "_links": {
-                    "self": {
-                        "href": "https://api.mollie.com/v2/orders/ord_pbjz8x/orderlines/odl_dgtxyl",
-                        "type": "application/hal+json"
+                    "productUrl": {
+                        "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                        "type": "text/html"
+                    },
+                    "imageUrl": {
+                        "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                        "type": "text/html"
                     }
                 }
             },
@@ -166,8 +164,6 @@ Response
                 "id": "odl_jp31jz",
                 "orderId": "ord_pbjz8x",
                 "name": "LEGO 42056 Porsche 911 GT3 RS",
-                "productUrl": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
-                "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
                 "sku": "5702015594028",
                 "type": "physical",
                 "status": "canceled",
@@ -188,6 +184,9 @@ Response
                     "value": "329.99",
                     "currency": "EUR"
                 },
+                "shippableQuantity": 0,
+                "refundableQuantity": 0,
+                "cancelableQuantity": 0,
                 "unitPrice": {
                     "value": "329.99",
                     "currency": "EUR"
@@ -203,9 +202,13 @@ Response
                 },
                 "createdAt": "2018-08-02T09:29:56+00:00",
                 "_links": {
-                    "self": {
-                        "href": "https://api.mollie.com/v2/orders/ord_pbjz8x/orderlines/odl_jp31jz",
-                        "type": "application/hal+json"
+                    "productUrl": {
+                        "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                        "type": "text/html"
+                    },
+                    "imageUrl": {
+                        "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                        "type": "text/html"
                     }
                 }
             }

--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -78,7 +78,6 @@ Response
         "isCancelable": false,
         "metadata": null,
         "createdAt": "2018-08-02T09:29:56+00:00",
-        "expiresAt": "2018-08-30T09:29:56+00:00",
         "mode": "live",
         "locale": "nl_NL",
         "billingAddress": {
@@ -100,6 +99,7 @@ Response
             "familyName": "Skywalker",
             "email": "luke@skywalker.com"
         },
+        "canceledAt": "2018-08-03T09:29:56+00:00",
         "redirectUrl": "https://example.org/redirect",
         "lines": [
             {

--- a/source/reference/v2/orders-api/create-order-refund.rst
+++ b/source/reference/v2/orders-api/create-order-refund.rst
@@ -147,19 +147,17 @@ Response
                "id": "odl_dgtxyl",
                "orderId": "ord_stTC2WHAuS",
                "name": "LEGO 42083 Bugatti Chiron",
-               "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
-               "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
                "sku": "5702016116977",
                "type": "physical",
-               "status": "refunded",
-               "quantity": 2,
+               "status": "paid",
+               "quantity": 1,
                "unitPrice": {
                    "value": "399.00",
                    "currency": "EUR"
                },
                "vatRate": "21.00",
                "vatAmount": {
-                   "value": "121.14",
+                   "value": "51.89",
                    "currency": "EUR"
                },
                "discountAmount": {
@@ -167,10 +165,20 @@ Response
                    "currency": "EUR"
                },
                "totalAmount": {
-                   "value": "698.00",
+                   "value": "299.00",
                    "currency": "EUR"
                },
-               "createdAt": "2018-08-02T09:29:56+00:00"
+               "createdAt": "2018-08-02T09:29:56+00:00",
+               "_links": {
+                   "productUrl": {
+                       "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                       "type": "text/html"
+                   },
+                   "imageUrl": {
+                       "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                       "type": "text/html"
+                   }
+               }
            }
        ],
        "_links": {

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -609,14 +609,6 @@ Response
            "value": "1027.99",
            "currency": "EUR"
        },
-       "amountCaptured": {
-           "value": "0.00",
-           "currency": "EUR"
-       },
-       "amountRefunded": {
-           "value": "0.00",
-           "currency": "EUR"
-       },
        "status": "created",
        "isCancelable": true,
        "metadata": {
@@ -627,7 +619,6 @@ Response
        "expiresAt": "2018-08-30T09:29:56+00:00",
        "mode": "test",
        "locale": "nl_NL",
-       "orderNumber": "1337",
        "billingAddress": {
            "streetAndNumber": "Keizersgracht 313",
            "city": "Amsterdam",
@@ -640,6 +631,8 @@ Response
            "email": "piet@mondriaan.com",
            "phone": "+31309202070"
        },
+       "consumerDateOfBirth": "1958-01-31",
+       "orderNumber": "1337",
        "shippingAddress": {
            "streetAndNumber": "Keizersgracht 313",
            "streetAdditional": "4th floor",
@@ -652,18 +645,18 @@ Response
            "familyName": "Norris",
            "email": "norris@chucknorrisfacts.net",
        },
+       "redirectUrl": "https://example.org/redirect",
+       "webhookUrl": "https://example.org/webhook",
        "lines": [
            {
                "resource": "orderline",
                "id": "odl_dgtxyl",
                "orderId": "ord_pbjz8x",
                "name": "LEGO 42083 Bugatti Chiron",
-               "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
-               "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
                "sku": "5702016116977",
                "type": "physical",
                "status": "created",
-               "isCancelable": true,
+               "isCancelable": false,
                "quantity": 2,
                "quantityShipped": 0,
                "amountShipped": {
@@ -680,6 +673,9 @@ Response
                    "value": "0.00",
                    "currency": "EUR"
                },
+               "shippableQuantity": 0,
+               "refundableQuantity": 0,
+               "cancelableQuantity": 0,
                "unitPrice": {
                    "value": "399.00",
                    "currency": "EUR"
@@ -697,19 +693,27 @@ Response
                    "value": "698.00",
                    "currency": "EUR"
                },
-               "createdAt": "2018-08-02T09:29:56+00:00"
+               "createdAt": "2018-08-02T09:29:56+00:00",
+               "_links": {
+                   "productUrl": {
+                       "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                       "type": "text/html"
+                   },
+                   "imageUrl": {
+                       "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                       "type": "text/html"
+                   }
+               }
            },
            {
                "resource": "orderline",
                "id": "odl_jp31jz",
                "orderId": "ord_pbjz8x",
                "name": "LEGO 42056 Porsche 911 GT3 RS",
-               "productUrl": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
-               "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
                "sku": "5702015594028",
                "type": "physical",
                "status": "created",
-               "isCancelable": true,
+               "isCancelable": false,
                "quantity": 1,
                "quantityShipped": 0,
                "amountShipped": {
@@ -726,6 +730,9 @@ Response
                    "value": "0.00",
                    "currency": "EUR"
                },
+               "shippableQuantity": 0,
+               "refundableQuantity": 0,
+               "cancelableQuantity": 0,
                "unitPrice": {
                    "value": "329.99",
                    "currency": "EUR"
@@ -739,7 +746,17 @@ Response
                    "value": "329.99",
                    "currency": "EUR"
                },
-               "createdAt": "2018-08-02T09:29:56+00:00"
+               "createdAt": "2018-08-02T09:29:56+00:00",
+               "_links": {
+                   "productUrl": {
+                       "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                       "type": "text/html"
+                   },
+                   "imageUrl": {
+                       "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                       "type": "text/html"
+                   }
+               }
            }
        ],
        "_links": {

--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -113,7 +113,6 @@ Response
        * ``paid``
        * ``authorized``
        * ``canceled``
-       * ``refunded``
        * ``shipping``
        * ``completed``
        * ``expired``
@@ -245,7 +244,7 @@ Response
 
        .. type:: object
 
-     - An object with several URL objects relevant to the customer. Every URL object will contain an ``href`` and a
+     - An object with several URL objects relevant to the order. Every URL object will contain an ``href`` and a
        ``type`` field.
 
        .. list-table::
@@ -334,7 +333,6 @@ The order lines contain the actual things the your customer bought.
        * ``paid``
        * ``shipping``
        * ``canceled``
-       * ``refunded``
        * ``completed``
 
    * - ``isCancelable``
@@ -385,6 +383,24 @@ The order lines contain the actual things the your customer bought.
 
      - The total amount that is canceled in this order line.
 
+   * - ``shippableQuantity``
+
+       .. type:: int
+
+     - The number of items that can still be shipped for this order line.
+
+   * - ``refundableQuantity``
+
+       .. type:: int
+
+     - The number of items that can still be refunded for this order line.
+
+   * - ``cancelableQuantity``
+
+       .. type:: int
+
+     - The number of items that can still be canceled for this order line.
+
    * - ``unitPrice``
 
        .. type:: amount object
@@ -424,25 +440,35 @@ The order lines contain the actual things the your customer bought.
 
      - The SKU, EAN, ISBN or UPC of the product sold.
 
-   * - ``imageUrl``
-
-       .. type:: string
-          :required: false
-
-     - A link pointing to an image of the product sold.
-
-   * - ``productUrl``
-
-       .. type:: string
-          :required: false
-
-     - A link pointing to the product page in your web shop of the product sold.
-
    * - ``createdAt``
 
        .. type:: datetime
 
      - The order line's date and time of creation, in `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ format.
+
+   * - ``_links``
+
+       .. type:: object
+
+     - An object with several URL objects relevant to the order line. Every URL object will contain an ``href`` and a
+       ``type`` field.
+
+       .. list-table::
+          :widths: auto
+
+          * - ``productUrl``
+
+              .. type:: string
+                 :required: false
+
+            - A link pointing to the product page in your web shop of the product sold.
+
+          * - ``imageUrl``
+
+              .. type:: string
+                 :required: false
+
+            - A link pointing to an image of the product sold.
 
 Addresses
 ^^^^^^^^^
@@ -533,14 +559,6 @@ Response
             "value": "1027.99",
             "currency": "EUR"
         },
-        "amountCaptured": {
-            "value": "0.00",
-            "currency": "EUR"
-        },
-        "amountRefunded": {
-            "value": "0.00",
-            "currency": "EUR"
-        },
         "status": "created",
         "isCancelable": true,
         "metadata": null,
@@ -548,7 +566,6 @@ Response
         "expiresAt": "2018-08-30T09:29:56+00:00",
         "mode": "live",
         "locale": "nl_NL",
-        "orderNumber": "18475",
         "billingAddress": {
             "streetAndNumber": "Keizersgracht 313",
             "postalCode": "1016 EE",
@@ -558,6 +575,7 @@ Response
             "familyName": "Skywalker",
             "email": "luke@skywalker.com"
         },
+        "orderNumber": "18475",
         "shippingAddress": {
             "streetAndNumber": "Keizersgracht 313",
             "postalCode": "1016 EE",
@@ -567,18 +585,17 @@ Response
             "familyName": "Skywalker",
             "email": "luke@skywalker.com"
         },
+        "redirectUrl": "https://example.org/redirect",
         "lines": [
             {
                 "resource": "orderline",
                 "id": "odl_dgtxyl",
                 "orderId": "ord_pbjz8x",
                 "name": "LEGO 42083 Bugatti Chiron",
-                "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
-                "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
                 "sku": "5702016116977",
                 "type": "physical",
                 "status": "created",
-                "isCancelable": true,
+                "isCancelable": false,
                 "quantity": 2,
                 "quantityShipped": 0,
                 "amountShipped": {
@@ -595,6 +612,9 @@ Response
                     "value": "0.00",
                     "currency": "EUR"
                 },
+                "shippableQuantity": 0,
+                "refundableQuantity": 0,
+                "cancelableQuantity": 0,
                 "unitPrice": {
                     "value": "399.00",
                     "currency": "EUR"
@@ -612,19 +632,27 @@ Response
                     "value": "698.00",
                     "currency": "EUR"
                 },
-                "createdAt": "2018-08-02T09:29:56+00:00"
+                "createdAt": "2018-08-02T09:29:56+00:00",
+                "_links": {
+                    "productUrl": {
+                        "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                        "type": "text/html"
+                    },
+                    "imageUrl": {
+                        "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                        "type": "text/html"
+                    }
+                }
             },
             {
                 "resource": "orderline",
                 "id": "odl_jp31jz",
                 "orderId": "ord_pbjz8x",
                 "name": "LEGO 42056 Porsche 911 GT3 RS",
-                "productUrl": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
-                "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
                 "sku": "5702015594028",
                 "type": "physical",
                 "status": "created",
-                "isCancelable": true,
+                "isCancelable": false,
                 "quantity": 1,
                 "quantityShipped": 0,
                 "amountShipped": {
@@ -641,6 +669,9 @@ Response
                     "value": "0.00",
                     "currency": "EUR"
                 },
+                "shippableQuantity": 0,
+                "refundableQuantity": 0,
+                "cancelableQuantity": 0,
                 "unitPrice": {
                     "value": "329.99",
                     "currency": "EUR"
@@ -654,7 +685,17 @@ Response
                     "value": "329.99",
                     "currency": "EUR"
                 },
-                "createdAt": "2018-08-02T09:29:56+00:00"
+                "createdAt": "2018-08-02T09:29:56+00:00",
+                "_links": {
+                    "productUrl": {
+                        "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                        "type": "text/html"
+                    },
+                    "imageUrl": {
+                        "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                        "type": "text/html"
+                    }
+                }
             }
         ],
         "_embedded": {

--- a/source/reference/v2/orders-api/list-order-refunds.rst
+++ b/source/reference/v2/orders-api/list-order-refunds.rst
@@ -16,7 +16,9 @@ List order refunds
    :api_keys: true
    :oauth: true
 
-Retrieve order refunds. The results are paginated. See :doc:`pagination </guides/pagination>` for more information.
+Retrieve all order refunds.
+
+The results are paginated. See :doc:`pagination </guides/pagination>` for more information.
 
 Parameters
 ----------
@@ -164,19 +166,17 @@ Response
                            "id": "odl_dgtxyl",
                            "orderId": "ord_stTC2WHAuS",
                            "name": "LEGO 42083 Bugatti Chiron",
-                           "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
-                           "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
                            "sku": "5702016116977",
                            "type": "physical",
-                           "status": "refunded",
-                           "quantity": 2,
+                           "status": "paid",
+                           "quantity": 1,
                            "unitPrice": {
                                "value": "399.00",
                                "currency": "EUR"
                            },
                            "vatRate": "21.00",
                            "vatAmount": {
-                               "value": "121.14",
+                               "value": "51.89",
                                "currency": "EUR"
                            },
                            "discountAmount": {
@@ -184,10 +184,20 @@ Response
                                "currency": "EUR"
                            },
                            "totalAmount": {
-                               "value": "698.00",
+                               "value": "299.00",
                                "currency": "EUR"
                            },
-                           "createdAt": "2018-08-02T09:29:56+00:00"
+                           "createdAt": "2018-08-02T09:29:56+00:00",
+                           "_links": {
+                               "productUrl": {
+                                   "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                                   "type": "text/html"
+                               },
+                               "imageUrl": {
+                                   "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                                   "type": "text/html"
+                               }
+                           }
                        }
                    ],
                    "_links": {

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -133,14 +133,6 @@ Response
             "value": "1027.99",
             "currency": "EUR"
         },
-        "amountCaptured": {
-            "value": "0.00",
-            "currency": "EUR"
-        },
-        "amountRefunded": {
-            "value": "0.00",
-            "currency": "EUR"
-        },
         "status": "created",
         "isCancelable": true,
         "metadata": null,
@@ -148,7 +140,6 @@ Response
         "expiresAt": "2018-08-30T09:29:56+00:00",
         "mode": "live",
         "locale": "nl_NL",
-        "orderNumber": "18475",
         "billingAddress": {
             "streetAndNumber": "Keizersgracht 313",
             "city": "Amsterdam",
@@ -161,6 +152,7 @@ Response
             "email": "piet@mondriaan.com",
             "phone": "+31208202070"
         },
+        "orderNumber": "18475",
         "shippingAddress": {
             "streetAndNumber": "Keizersgracht 313",
             "postalCode": "1016 EE",
@@ -170,18 +162,17 @@ Response
             "familyName": "Skywalker",
             "email": "luke@skywalker.com"
         },
+       "redirectUrl": "https://example.org/redirect",
         "lines": [
             {
                 "resource": "orderline",
                 "id": "odl_dgtxyl",
                 "orderId": "ord_pbjz8x",
                 "name": "LEGO 42083 Bugatti Chiron",
-                "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
-                "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
                 "sku": "5702016116977",
                 "type": "physical",
                 "status": "created",
-                "isCancelable": true,
+                "isCancelable": false,
                 "quantity": 2,
                 "quantityShipped": 0,
                 "amountShipped": {
@@ -198,6 +189,9 @@ Response
                     "value": "0.00",
                     "currency": "EUR"
                 },
+               "shippableQuantity": 0,
+               "refundableQuantity": 0,
+               "cancelableQuantity": 0,
                 "unitPrice": {
                     "value": "399.00",
                     "currency": "EUR"
@@ -215,19 +209,27 @@ Response
                     "value": "698.00",
                     "currency": "EUR"
                 },
-                "createdAt": "2018-08-02T09:29:56+00:00"
+                "createdAt": "2018-08-02T09:29:56+00:00",
+                "_links": {
+                    "productUrl": {
+                        "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                        "type": "text/html"
+                    },
+                    "imageUrl": {
+                        "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                        "type": "text/html"
+                    }
+                }
             },
             {
                 "resource": "orderline",
                 "id": "odl_jp31jz",
                 "orderId": "ord_pbjz8x",
                 "name": "LEGO 42056 Porsche 911 GT3 RS",
-                "productUrl": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
-                "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
                 "sku": "5702015594028",
                 "type": "physical",
                 "status": "created",
-                "isCancelable": true,
+                "isCancelable": false,
                 "quantity": 1,
                 "quantityShipped": 0,
                 "amountShipped": {
@@ -244,6 +246,9 @@ Response
                     "value": "0.00",
                     "currency": "EUR"
                 },
+               "shippableQuantity": 0,
+               "refundableQuantity": 0,
+               "cancelableQuantity": 0,
                 "unitPrice": {
                     "value": "329.99",
                     "currency": "EUR"
@@ -257,7 +262,17 @@ Response
                     "value": "329.99",
                     "currency": "EUR"
                 },
-                "createdAt": "2018-08-02T09:29:56+00:00"
+                "createdAt": "2018-08-02T09:29:56+00:00",
+                "_links": {
+                    "productUrl": {
+                        "href": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                        "type": "text/html"
+                    },
+                    "imageUrl": {
+                        "href": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                        "type": "text/html"
+                    }
+                }
             }
         ],
         "_links": {


### PR DESCRIPTION
General improvements
- Removed the `refunded` state for orders and order lines.
- `amountCaptured` and `amountRefunded` should only be returned in the order response if they are > 0.
- Added the `shippableQuantity`, `refundableQuantity` and `cancelableQuantity` properties for order lines in the response examples.
- `productUrl` and `imageUrl` are links, not direct properties of the order line.
- Improved the order state changes guide.

Specific improvements
- `cancelOrderlines` API can only be used with `authorized` or `shipping` lines.
- `createOrderRefund` API response should describe the partial order line, not the whole order line.