### PR TITLE
Use WGAC compliant color for syntax highlighting

### DIFF
--- a/source/theme/styles/components/_highlight.scss
+++ b/source/theme/styles/components/_highlight.scss
@@ -81,10 +81,7 @@
 }
 
 .rst-content .highlight-bash .highlight .s2,
-.rst-content .highlight-bash .highlight .se {
-  color: $brand-primary;
-}
-
+.rst-content .highlight-bash .highlight .se,
 .rst-content .highlight-php .highlight .cp,
 .rst-content .highlight-php .highlight .nv,
 .rst-content .highlight-php .highlight .k,
@@ -92,7 +89,7 @@
 .rst-content .highlight-php .highlight .c1,
 .rst-content .highlight-php .highlight .o,
 .rst-content .highlight-php .highlight .na {
-  color: $brand-primary;
+  color: #005a9a;
 }
 
 .rst-content .highlight-php .highlight .mi {


### PR DESCRIPTION
Fixes #149. Improved based on [the feedback in my previous PR](https://github.com/mollie/api-documentation/pull/218#issuecomment-420959663).

----

@sandervanhooft What do you think?

![image](https://user-images.githubusercontent.com/2484832/46295351-21594700-c598-11e8-874e-b41ca8d94101.png)
