### PR TITLE
PROC-1453 Add link for changing recurring payment state

### DIFF
--- a/source/changelog/v1/changelog.rst
+++ b/source/changelog/v1/changelog.rst
@@ -9,7 +9,7 @@ October 2018
 Wednesday, 24th
 ---------------
 
-- Consumer IBAN’s of Bancontact payments will now always be shared via the API.
+- Consumer IBANs of Bancontact payments will now always be shared via the API.
 
 Friday, 19th
 --------------

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -9,14 +9,17 @@ October 2018
 Thursday, 25th
 --------------
 
-- We now accept the use of an underscore ``_`` in Redirect- en Webhook-URLs.
+- We now accept the use of an underscore ``_`` in Redirect- and Webhook-URLs.
+- A :doc:`guide </guides/testing>` has been added explaining how to test your integration of the Mollie API.
+- Added the ``changePaymentState`` link to the :doc:`Payments API </reference/v2/payments-api/get-payment>`.
+  It allows you to set the final payment state for test mode recurring payments.
 
 Wednesday, 24th
 ---------------
 
 - Added the ``timesRemaining`` field to the :doc:`Subscriptions API </reference/v2/subscriptions-api/get-subscription>`
   to see how many charges are left for completing the subscription.
-- Consumer IBAN’s of Bancontact payments will now always be shared via the API.
+- Consumer IBANs of Bancontact payments will now always be shared via the API.
 
 Friday, 19th
 --------------
@@ -94,7 +97,7 @@ Wednesday, 12th
 ---------------
 - Added the :doc:`Orders API </reference/v2/orders-api/create-order>` and the
   :doc:`Shipments API </reference/v2/shipments-api/create-shipment>`. See the
-  :doc:`Orders API overview </orders/overview>` for more details on how to use these API's.
+  :doc:`Orders API overview </orders/overview>` for more details on how to use these APIs.
 
 - Added the :doc:`Captures API </reference/v2/captures-api/get-capture>`.
 

--- a/source/guides/authentication.rst
+++ b/source/guides/authentication.rst
@@ -17,8 +17,8 @@ The first thing you need is a `website profile <https://www.mollie.com/dashboard
 profile has a *Live API key* and a *Test API key*.
 
 While building and testing your integration, you should use the *Test API key*. Read more about the
-:ref:`test mode <guides/authentication/test-mode>` below. Once you're ready to start processing real payments, switch
-out your test key for the *Live API key*.
+test mode in our :doc:`guide </guides/testing>` about testing the Mollie API. Once you're ready to
+start processing real payments, switch out your test key for the *Live API key*.
 
 Of course it's very important to keep any API keys :doc:`secure </guides/security>`. Do not ever share them. However, if
 a key leaks you can always `regenerate <https://www.mollie.com/dashboard/developers/api-keys>`_ it. Don't forget to
@@ -114,21 +114,3 @@ For completeness' sake, the following table compares the available authenticatio
      - `Dashboard: Organization access tokens <https://www.mollie.com/dashboard/developers/organization-access-tokens>`_
      - :doc:`OAuth authorization flow </oauth/overview>`
 
-.. _guides/authentication/test-mode:
-
-Test mode
----------
-You can access the test mode of the Mollie API by using the *Test API key*. Or, if you're using access tokens, by
-providing the ``testmode`` parameter in your API request.
-
-Any payments or other resources you create in test mode are isolated completely from your live mode data. Going back and
-forth between test and live mode is as easy as switching out the API key - or toggling the ``testmode`` parameter in
-case of access tokens.
-
-When creating payments in test mode, the regular checkout screens will be replaced by a test mode checkout screen. This
-test screen allows you to try out different payment statuses without spending actual money.
-
-Apart from the hosted payment pages and the fact that test payments are created instead of real ones, the Mollie API
-behaves almost identical in both environments.
-
-Just be sure to start using live mode when your site goes public, or your customers will get a free ride.

--- a/source/guides/testing.rst
+++ b/source/guides/testing.rst
@@ -1,0 +1,26 @@
+Testing the Mollie API
+======================
+During the process of building your integration, it is important to properly test it. As briefly
+explained in our :doc:`authentication guide </guides/authentication>`, you can access the test mode
+of the Mollie API in two ways: by using the *Test API key*, or, if you're using access tokens, by
+providing the ``testmode`` parameter in your API request.
+
+Any payments or other resources you create in test mode are completely isolated from your live mode
+data. Going back and forth between test and live mode is as easy as switching out the API key - or
+toggling the ``testmode`` parameter in case of access tokens.
+
+Test mode checkout screen
+-------------------------
+When creating payments in test mode, the regular checkout screen will be replaced by a test mode
+checkout screen. Most test mode payment resources will feature a ``checkout`` URL just like in live
+mode, which then allows you to walk through the payment process without spending actual money. You
+can try out different payment statuses and see whether your integration handles it correctly.
+
+For test mode *recurring* payments, the resource will not contain a ``checkout`` URL, because these
+payments are executed without any user interaction. Instead, a ``changePaymentState`` URL is added,
+which allows you to set the final payment state for these payments.
+
+Apart from the hosted payment pages and the fact that test mode payments are created instead of real
+ones, the Mollie API behaves almost identical in both environments. This includes calling your
+webhook. Just make sure to start using live mode when your site goes public, or your customers will
+get a free ride.

--- a/source/guides/testing.rst
+++ b/source/guides/testing.rst
@@ -2,25 +2,25 @@ Testing the Mollie API
 ======================
 During the process of building your integration, it is important to properly test it. As briefly
 explained in our :doc:`authentication guide </guides/authentication>`, you can access the test mode
-of the Mollie API in two ways: by using the *Test API key*, or, if you're using access tokens, by
-providing the ``testmode`` parameter in your API request.
+of the Mollie API in two ways: by using the *Test API key*, or, if you're using organization access
+tokens or app tokens, by providing the ``testmode`` parameter in your API request.
 
 Any payments or other resources you create in test mode are completely isolated from your live mode
 data. Going back and forth between test and live mode is as easy as switching out the API key - or
-toggling the ``testmode`` parameter in case of access tokens.
+toggling the ``testmode`` parameter in case of the other authentication methods.
 
 Test mode checkout screen
 -------------------------
-When creating payments in test mode, the regular checkout screen will be replaced by a test mode
+When creating payments or orders in test mode, the regular checkout screen will be replaced by a test mode
 checkout screen. Most test mode payment resources will feature a ``checkout`` URL just like in live
 mode, which then allows you to walk through the payment process without spending actual money. You
 can try out different payment statuses and see whether your integration handles it correctly.
 
 For test mode *recurring* payments, the resource will not contain a ``checkout`` URL, because these
-payments are executed without any user interaction. Instead, a ``changePaymentState`` URL is added,
-which allows you to set the final payment state for these payments.
+payments are executed without any interaction of your customer. Instead, a ``changePaymentState``
+URL is added, which allows you to set the final payment state for these payments.
 
 Apart from the hosted payment pages and the fact that test mode payments are created instead of real
 ones, the Mollie API behaves almost identical in both environments. This includes calling your
-webhook. Just make sure to start using live mode when your site goes public, or your customers will
-get a free ride.
+:doc:`webhook </guides/webhooks>`. Just make sure to start using live mode when your site goes public,
+or your customers will get a free ride.

--- a/source/payments/multicurrency.rst
+++ b/source/payments/multicurrency.rst
@@ -8,7 +8,7 @@ the conversion. You can retrieve the settlement amount via the API or view it in
 When creating a payment in a non-EUR currency, we will immediately give you the amount we will settle in the API
 response.
 
-Creating payments, refunds or subscriptions in a different currency than ``EUR`` is only possible via the ``v2`` API.
+Creating payments, orders, refunds or subscriptions in a different currency than ``EUR`` is only possible via the ``v2`` API.
 Review the :doc:`Payments API reference </reference/v2/payments-api/create-payment>` for more information.
 
 Payments in non-EUR currencies (created via the ``v2`` API) that are retrieved via the ``v1`` API will show the

--- a/source/payments/recurring.rst
+++ b/source/payments/recurring.rst
@@ -23,6 +23,8 @@ In the following sections we explain the following topics.
 * :ref:`Charging periodically with subscriptions <payments/recurring/charging-periodically>`
 * :ref:`How do webhooks for subscriptions work? <payments/recurring/subscription-webhooks>`
 
+For more information on how to test recurring payments, please refer to our :doc:`guide </guides/testing>` for testing the Mollie API.
+
 .. _payments/recurring/first-payment:
 
 Setting up the first payment

--- a/source/reference/reseller-api/guides/secret-keys.rst
+++ b/source/reference/reseller-api/guides/secret-keys.rst
@@ -1,6 +1,6 @@
 Secret keys and authentication
 ==============================
-**Secret keys** facilitate encrypted communication with Mollie's Reseller API’s. These API's provide even better security
+**Secret keys** facilitate encrypted communication with Mollie's Reseller APIs. These APIs provide even better security
 than the previous ones because:
 
 **Authentication is performed by means of a** ``profile_key`` **:**

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -415,6 +415,7 @@ Response
           * - ``checkout``
 
               .. type:: URL object
+                 :required: false
 
             - The URL your customer should visit to make the payment. This is where you should redirect the
               consumer to.
@@ -424,6 +425,15 @@ Response
                          ``303 See Other`` to force an HTTP ``GET`` redirect.
 
               Recurring payments don't have a checkout URL.
+
+          * - ``changePaymentState``
+
+              .. type:: URL object
+                 :required: false
+
+            - Recurring payments do not have a checkout URL, because these payments are executed without
+              any user interaction. This link is only included for test recurring payments, and allows you
+              to set the final payment state for such payments.
 
           * - ``refunds``
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -434,8 +434,8 @@ Response
                  :required: false
 
             - Recurring payments do not have a checkout URL, because these payments are executed without
-              any user interaction. This link is only included for test recurring payments, and allows you
-              to set the final payment state for such payments.
+              any user interaction. This link is only included for test mode recurring payments, and allows
+              you to set the final payment state for such payments.
 
           * - ``refunds``
 

--- a/source/theme/sidebar-guides.html
+++ b/source/theme/sidebar-guides.html
@@ -7,6 +7,7 @@
 		{{ sidebar_item('index', 'Overview') }}
 		{{ sidebar_item('guides/security', 'Security') }}
 		{{ sidebar_item('guides/authentication', 'Authentication') }}
+    {{ sidebar_item('guides/testing', 'Testing') }}
 		{{ sidebar_item('guides/checkout', 'Mollie Checkout') }}
 		{{ sidebar_item('guides/common-data-types', 'Common data types') }}
 		{{ sidebar_item('guides/handling-errors', 'Handling errors') }}


### PR DESCRIPTION
- `checkout` url is optional, because recurring payment do not have it.
- The `changePaymentState` url is used to change the payment state of recurring payments.