### PR TITLE
Add "klarnasliceit" and "klarnapaylater" to possible method values in GET payment

### DIFF
--- a/source/reference/v1/payments-api/get-payment.rst
+++ b/source/reference/v1/payments-api/get-payment.rst
@@ -175,7 +175,7 @@ Response
 
        Possible values: ``banktransfer`` ``belfius`` ``bitcoin`` ``creditcard`` ``directdebit`` ``eps``, ``giftcard``
        ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``klarnapaylater`` ``klarnasliceit`` ``mistercash`` ``paypal``
-       ``paysafecard`` ``sofort``
+       ``paysafecard`` ``sofort`` ``klarnasliceit`` ``klarnapaylater``
 
    * - ``metadata``
 

--- a/source/reference/v1/payments-api/get-payment.rst
+++ b/source/reference/v1/payments-api/get-payment.rst
@@ -175,7 +175,7 @@ Response
 
        Possible values: ``banktransfer`` ``belfius`` ``bitcoin`` ``creditcard`` ``directdebit`` ``eps``, ``giftcard``
        ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``klarnapaylater`` ``klarnasliceit`` ``mistercash`` ``paypal``
-       ``paysafecard`` ``sofort`` ``klarnasliceit`` ``klarnapaylater``
+       ``paysafecard`` ``sofort``
 
    * - ``metadata``
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -268,9 +268,9 @@ Response
 
        If the payment is only partially paid with a gift card, the method remains ``giftcard``.
 
-       Possible values: ``bancontact`` ``banktransfer`` ``belfius`` ``bitcoin`` ``creditcard`` ``directdebit`` ``eps``
-       ``giftcard`` ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``paypal`` ``paysafecard`` ``sofort``
-       ``klarnasliceit`` ``klarnapaylater``
+       Possible values: ``banktransfer`` ``belfius`` ``bitcoin`` ``creditcard`` ``directdebit`` ``eps``, ``giftcard``
+       ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``klarnapaylater`` ``klarnasliceit`` ``mistercash`` ``paypal``
+       ``paysafecard`` ``sofort``
 
    * - ``metadata``
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -270,6 +270,7 @@ Response
 
        Possible values: ``bancontact`` ``banktransfer`` ``belfius`` ``bitcoin`` ``creditcard`` ``directdebit`` ``eps``
        ``giftcard`` ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``paypal`` ``paysafecard`` ``sofort``
+       ``klarnasliceit`` ``klarnapaylater``
 
    * - ``metadata``
 


### PR DESCRIPTION
It is possible to retrieve a payment created by an order that uses Klarna.