### PR TITLE
Chargebacks: pagination info, improved php example

### DIFF
--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -125,6 +125,7 @@ Example
       $chargebacks = $payment->chargebacks();
 
       // List chargebacks across all payments on the payment profile
+      // (For all chargebacks on the organizations, use an OAuth or Organization access token.)
       $all_chargebacks = $mollie->chargebacks->page();
 
    .. code-block:: python

--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -102,8 +102,12 @@ Example
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
 
+      // Listing chargebacks for a single payment
       $payment = $mollie->payments->get("tr_7UhSN1zuXS");
       $chargebacks = $payment->chargebacks();
+
+      // Listing all chargebacks
+      $all_chargebacks = $mollie->chargebacks->all();
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -19,12 +19,30 @@ List chargebacks
 Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment
 are returned.
 
-The results are not paginated.
+The results are paginated. See :doc:`pagination </guides/pagination>` for more information.
 
 Parameters
 ----------
 When using the payment-specific endpoint, replace ``paymentId`` in the endpoint URL by the payment's ID, for example
 ``tr_7UhSN1zuXS``.
+
+.. list-table::
+   :widths: auto
+
+   * - ``from``
+
+       .. type:: string
+          :required: false
+
+     - Offset the result set to the chargeback with this ID. The chargeback with this ID is included in the result
+       set as well.
+
+   * - ``limit``
+
+       .. type:: integer
+          :required: false
+
+     - The number of chargebacks to return (with a maximum of 250).
 
 Embedding of related resources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,8 +124,8 @@ Example
       $payment = $mollie->payments->get("tr_7UhSN1zuXS");
       $chargebacks = $payment->chargebacks();
 
-      // Listing all chargebacks
-      $all_chargebacks = $mollie->chargebacks->all();
+      // Listing chargebacks across all payments
+      $all_chargebacks = $mollie->chargebacks->page();
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -120,11 +120,11 @@ Example
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
 
-      // Listing chargebacks for a single payment
+      // List chargebacks for a single payment
       $payment = $mollie->payments->get("tr_7UhSN1zuXS");
       $chargebacks = $payment->chargebacks();
 
-      // Listing chargebacks across all payments
+      // List chargebacks across all payments on the payment profile
       $all_chargebacks = $mollie->chargebacks->page();
 
    .. code-block:: python


### PR DESCRIPTION
Added example for listing all chargebacks using the (root) chargebacks endpoint.

The new endpoint is not yet released.