### PR TITLE
Adds Payment method switcher

### DIFF
--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -404,6 +404,8 @@ KBC/CBC Payment Button
 
        Possible values: ``kbc`` ``cbc``
 
+.. _paypal-method-details:
+
 PayPal
 """"""
 .. list-table::

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -404,8 +404,6 @@ KBC/CBC Payment Button
 
        Possible values: ``kbc`` ``cbc``
 
-.. _paypal-method-details:
-
 PayPal
 """"""
 .. list-table::

--- a/source/theme/js/index.js
+++ b/source/theme/js/index.js
@@ -8,6 +8,7 @@ import toggleMobileNavigation from './mobileNavigation';
 import toggleClass from './toggleClass';
 import exampleSwitcher from './exampleSwitcher';
 import linkDropdown from './linkDropdown';
+import { addPaymentMethodDropdown, linkDropdownPaymentMethods } from './linkDropdownPaymentMethods';
 import sidebar from './sidebar';
 
 const handlers = makeHandlers([toggleClass, toggleMobileNavigation]);
@@ -18,10 +19,12 @@ const enhancers = makeEnhancers([
   mobileNavigationButton,
   sidebar,
   linkDropdown,
+  linkDropdownPaymentMethods,
   exampleSwitcher,
 ]);
 
 const main = () => {
+  addPaymentMethodDropdown();
   bindHandlers(handlers);
   executeEnhancers(enhancers);
 };

--- a/source/theme/js/linkDropdownPaymentMethods.js
+++ b/source/theme/js/linkDropdownPaymentMethods.js
@@ -1,0 +1,53 @@
+import { enhance } from './utils';
+import Dropkick from 'dropkickjs';
+
+const DEFAULT_METHOD = 'bancontact';
+
+export const linkDropdownPaymentMethods = enhance('payment-method-switcher', element => {
+  element.addEventListener('change', () => {
+    element.childNodes.forEach(method => {
+      const selectedElement = document.getElementById(method.value);
+      if (method.value !== element.value) {
+        selectedElement.classList.add('u-screenreader-only');
+        selectedElement.setAttribute('aria-hidden', 'true');
+      } else {
+        selectedElement.classList.remove('u-screenreader-only');
+        selectedElement.setAttribute('aria-hidden', 'false');
+        localStorage.setItem('preferredPaymentMethod', method.value);
+      }
+    });
+  });
+
+  new Dropkick(element, {
+    mobile: false,
+  });
+});
+export const addPaymentMethodDropdown = () => {
+  const paymentMethodsBlock = document.querySelectorAll('[id^=payment-method]');
+  const storedMethod = localStorage.getItem('preferredPaymentMethod');
+  let preferredMethod;
+  if (storedMethod && storedMethod !== 'undefined') {
+    preferredMethod = storedMethod;
+  } else {
+    preferredMethod = DEFAULT_METHOD;
+  }
+  if (paymentMethodsBlock.length) {
+    const paymentMethods = paymentMethodsBlock[0].childNodes;
+    let options = '';
+    paymentMethods.forEach(method => {
+      if (method.nodeName === 'DIV') {
+        const isSelected = method.id === preferredMethod;
+        if (!isSelected) {
+          method.classList.add('u-screenreader-only');
+          method.setAttribute('aria-hidden', 'true');
+        }
+        const methodName = method.childNodes[1].textContent.replace('¶', '');
+        options += `<option value="${method.id}" ${
+          isSelected ? ' selected' : ''
+        }>${methodName}</option>`;
+      }
+    });
+    const dropdown = `<select data-enhancer="payment-method-switcher" class="link-dropdown">${options}</select>`;
+    paymentMethods[1].insertAdjacentHTML('afterbegin', dropdown);
+  }
+};

--- a/source/theme/js/linkDropdownPaymentMethods.js
+++ b/source/theme/js/linkDropdownPaymentMethods.js
@@ -30,15 +30,21 @@ export const addPaymentMethodDropdown = () => {
   //Gets all possible payment methods and the preferred one from storage
 
   // We need to get the payment methods block (different names in different pages, same prefix)
-  const paymentMethodsBlockArray = document.querySelectorAll('[id^=payment-method]');
+  const paymentMethods = document.querySelectorAll('[id^=payment-method-specific]');
 
-  if (paymentMethodsBlockArray.length) {
-    const paymentMethodsBlock = paymentMethodsBlockArray[0];
+  if (paymentMethods.length) {
+    const paymentMethodsBlock = paymentMethods[0];
+    const paymentMethodsBlockArray = Array.from(paymentMethodsBlock.childNodes);
 
-    // Get the prefered method, either from storage or the default one.
+    // Get the prefered method, from hash, storage or the default one.
     const storedMethod = localStorage.getItem('preferredPaymentMethod');
+    const hashMethod = window.location.hash && window.location.hash.replace('#', '');
+
     let preferredMethod;
-    if (storedMethod && storedMethod !== 'undefined') {
+
+    if (hashMethod) {
+      preferredMethod = hashMethod;
+    } else if (storedMethod && storedMethod !== 'undefined') {
       preferredMethod = storedMethod;
     } else {
       preferredMethod = DEFAULT_METHOD;
@@ -46,30 +52,30 @@ export const addPaymentMethodDropdown = () => {
 
     let options = '';
     let firstMethod;
-
-    // Adds the selector option for each method
-    paymentMethodsBlock.childNodes.forEach(method => {
+    paymentMethodsBlockArray.forEach(method => {
+      // Adds the selector option for each method (use classic for loop for IE11)
       // Inside the block, we are interested in the divs, not the title nor the description
-      if (method.nodeName === 'DIV') {
-        // We save the first payment method to append the dropdown to it later.
-        if (!firstMethod) {
-          firstMethod = method;
-        }
-        // Defined which one is selected && hide the rest
-        const isSelected = method.id === preferredMethod;
-        if (!isSelected) {
-          method.classList.add('u-screenreader-only');
-          method.setAttribute('aria-hidden', 'true');
-        }
-        // We need the payment method title to display it in the options
-        const methodTitle = method.getElementsByTagName('H4');
-        if (methodTitle.length) {
-          const methodName = methodTitle[0].textContent.replace('¶', '');
-          // Build the options, with their names and if they are selected or not
-          options += `<option value="${method.id}" ${
-            isSelected ? ' selected' : ''
-          }>${methodName}</option>`;
-        }
+      if (method.nodeName !== 'DIV') {
+        return;
+      }
+      // We save the first payment method to append the dropdown to it later.
+      if (!firstMethod) {
+        firstMethod = method;
+      }
+      // Defined which one is selected && hide the rest
+      const isSelected = method.id === preferredMethod;
+      if (!isSelected) {
+        method.classList.add('u-screenreader-only');
+        method.setAttribute('aria-hidden', 'true');
+      }
+      // We need the payment method title to display it in the options
+      const methodTitle = method.getElementsByTagName('H4');
+      if (methodTitle.length) {
+        const methodName = methodTitle[0].textContent.replace('¶', '');
+        // Build the options, with their names and if they are selected or not
+        options += `<option value="${method.id}" ${
+          isSelected ? ' selected' : ''
+        }>${methodName}</option>`;
       }
     });
     // We build the element and add it to the DOM

--- a/source/theme/js/linkDropdownPaymentMethods.js
+++ b/source/theme/js/linkDropdownPaymentMethods.js
@@ -1,7 +1,7 @@
 import { enhance } from './utils';
 import Dropkick from 'dropkickjs';
 
-const DEFAULT_METHOD = 'bancontact';
+const DEFAULT_METHOD = 'banktransfer';
 
 // Adds the onchange listener that hides/shows methods based on selection
 export const linkDropdownPaymentMethods = enhance('payment-method-switcher', element => {

--- a/source/theme/js/linkDropdownPaymentMethods.js
+++ b/source/theme/js/linkDropdownPaymentMethods.js
@@ -3,6 +3,7 @@ import Dropkick from 'dropkickjs';
 
 const DEFAULT_METHOD = 'bancontact';
 
+// Adds the onchange listener that hides/shows methods based on selection
 export const linkDropdownPaymentMethods = enhance('payment-method-switcher', element => {
   element.addEventListener('change', () => {
     element.childNodes.forEach(method => {
@@ -17,12 +18,18 @@ export const linkDropdownPaymentMethods = enhance('payment-method-switcher', ele
       }
     });
   });
-
+  // Initializes the select element we created
   new Dropkick(element, {
     mobile: false,
   });
 });
+
+// Adds the payment method dropdown to the DOM
+// We need to do this with JS, as the doc file is compiled from the .rst files
 export const addPaymentMethodDropdown = () => {
+  //Gets all possible payment methods and the preferred one from storage
+
+  // We need to get the payment methods block (different names in different pages, same prefix)
   const paymentMethodsBlock = document.querySelectorAll('[id^=payment-method]');
   const storedMethod = localStorage.getItem('preferredPaymentMethod');
   let preferredMethod;
@@ -34,20 +41,32 @@ export const addPaymentMethodDropdown = () => {
   if (paymentMethodsBlock.length) {
     const paymentMethods = paymentMethodsBlock[0].childNodes;
     let options = '';
+
+    // Adds the selector option for each method
     paymentMethods.forEach(method => {
+      // Inside the block, we are interested in the divs, not the title nor the description
       if (method.nodeName === 'DIV') {
+        // Defined which one is selected && hide the rest
         const isSelected = method.id === preferredMethod;
         if (!isSelected) {
           method.classList.add('u-screenreader-only');
           method.setAttribute('aria-hidden', 'true');
         }
+        // Build the options, with their names and if they are selected or not
         const methodName = method.childNodes[1].textContent.replace('¶', '');
         options += `<option value="${method.id}" ${
           isSelected ? ' selected' : ''
         }>${methodName}</option>`;
       }
     });
-    const dropdown = `<select data-enhancer="payment-method-switcher" class="link-dropdown">${options}</select>`;
-    paymentMethods[1].insertAdjacentHTML('afterbegin', dropdown);
+    // Creates select element
+    const dropdown = document.createElement('select');
+    // Adds attributes
+    dropdown.setAttribute('data-enhancer', 'payment-method-switcher');
+    dropdown.classList.add('link-dropdown', 'payment-methods');
+    // Adds the options we generated before
+    dropdown.innerHTML = options;
+    // Adds it after the title and description (there are text nodes, that's why the index is 5)
+    paymentMethodsBlock[0].insertBefore(dropdown, paymentMethods[5]);
   }
 };

--- a/source/theme/styles/components/_payment-method-switcher.scss
+++ b/source/theme/styles/components/_payment-method-switcher.scss
@@ -1,0 +1,5 @@
+.dk-select.payment-methods {
+    float: right;
+    margin-top: -5px;
+    width: 240px;
+}

--- a/source/theme/styles/components/_payment-method-switcher.scss
+++ b/source/theme/styles/components/_payment-method-switcher.scss
@@ -1,5 +1,10 @@
 .dk-select.payment-methods {
-    float: right;
-    margin-top: -5px;
-    width: 240px;
+  float: right;
+  width: 240px;
+  z-index: 1;
+
+  @media (max-width: breakpoint('<medium')) {
+    float: none;
+    margin-bottom: 15px;
+  }
 }

--- a/source/theme/styles/main.scss
+++ b/source/theme/styles/main.scss
@@ -135,7 +135,7 @@ a.headerlink::before {
 :target::before {
   content: '';
   display: block;
-  height: 130px;
+  height: 150px;
   margin: -130px 0 0;
 }
 

--- a/source/theme/styles/main.scss
+++ b/source/theme/styles/main.scss
@@ -204,6 +204,7 @@ a.headerlink::before {
 @import 'components/sub-navigation';
 @import 'components/sub-navigation-item';
 @import 'components/type';
+@import 'components/payment-method-switcher';
 
 /**
  * Utilities


### PR DESCRIPTION
Needs to be created with JS and appended to the DOM as we want it in the doc itself (that is compiled from the `.rst` files):

1) We create a dropdown element with the data-enhancer attribute.
   - This dropdown is generated based on the DOM, as we want to select based on payment methods present in that example
   - We use the existing content, such as names and ids for the methods to fill the options of the select.
   - We place the dropdown just before the first div in the payments method block, after the block's title and description. We have the method's name repeated but this compromise was the best solution.
2) We call the function that creates that dropdown before the enhancers runs.
3) The dropdown enhancer is called, just like the rest.
   - This enhancer hides and shows payment method blocks according to the select.
   - This enhancer saves the selected method to the local storage.