### PR TITLE
Php: Profile.delete returns null instead of resource

### DIFF
--- a/source/reference/v2/profiles-api/delete-profile.rst
+++ b/source/reference/v2/profiles-api/delete-profile.rst
@@ -38,7 +38,7 @@ Example
       <?php
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setAccessToken("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ");
-      $profile = $mollie->profiles->delete("pfl_v9hTwCvYqw");
+      $mollie->profiles->delete("pfl_v9hTwCvYqw");
 
 Response
 ^^^^^^^^


### PR DESCRIPTION
According to the docs, deleting the profile yields an empty `no content` response. In the php client, this means `null` is returned. So it's better to not store this null response in a `$profile` variable.