### PR TITLE
Payment switcher fix for non existing anchors

### DIFF
--- a/source/theme/js/linkDropdownPaymentMethods.js
+++ b/source/theme/js/linkDropdownPaymentMethods.js
@@ -42,7 +42,7 @@ export const addPaymentMethodDropdown = () => {
 
     let preferredMethod;
 
-    if (hashMethod && !!paymentMethodsBlockArray.some(m => m.id === hashMethod)) {
+    if (hashMethod && paymentMethodsBlockArray.some(m => m.id === hashMethod)) {
       preferredMethod = hashMethod;
     } else if (storedMethod && storedMethod !== 'undefined') {
       preferredMethod = storedMethod;

--- a/source/theme/js/linkDropdownPaymentMethods.js
+++ b/source/theme/js/linkDropdownPaymentMethods.js
@@ -42,7 +42,7 @@ export const addPaymentMethodDropdown = () => {
 
     let preferredMethod;
 
-    if (hashMethod) {
+    if (hashMethod && !!paymentMethodsBlockArray.some(m => m.id === hashMethod)) {
       preferredMethod = hashMethod;
     } else if (storedMethod && storedMethod !== 'undefined') {
       preferredMethod = storedMethod;


### PR DESCRIPTION
Navigating to this page with a non payment method anchor resulted in not showing a proper payment method.

This checks that the method exists before using it.