### PR TITLE
Add example response in webhook documentation

### DIFF
--- a/source/guides/webhooks.rst
+++ b/source/guides/webhooks.rst
@@ -16,14 +16,15 @@ and act accordingly. If the new payment status is ``paid`` you can start shippin
 .. code-block:: bash
       :linenos:
 
-          POST / HTTP/1.0
-            Host: https://webshop.example.org/payments/webhook
-            Via: 1.1 tinyproxy (tinyproxy/1.8.3)
-            Content-Type: application/x-www-form-urlencoded
-            Accept: */*
-            Accept-Encoding: deflate, gzip
-            Content-Length: 16
-            id=tr_d0b0E3EA3v
+      POST /payments/webhook HTTP/1.0
+      Host: https://webshop.example.org
+      Via: 1.1 tinyproxy (tinyproxy/1.8.3)
+      Content-Type: application/x-www-form-urlencoded
+      Accept: */*
+      Accept-Encoding: deflate, gzip
+      Content-Length: 16
+
+      id=tr_d0b0E3EA3v
 
 It might seem a little cumbersome that we don't post the new status immediately, but :doc:`proper security </guides/security>`
 dictates this flow. Since the status is not transmitted in the webhook, fake calls to your webhook will never result in

--- a/source/guides/webhooks.rst
+++ b/source/guides/webhooks.rst
@@ -13,6 +13,18 @@ will call that webhook URL with a single POST-parameter called ``id`` and a valu
 script behind your webhook URL should use that ID to :doc:`fetch the payment status </reference/v2/payments-api/get-payment>`
 and act accordingly. If the new payment status is ``paid`` you can start shipping the order.
 
+.. code-block:: bash
+      :linenos:
+
+          POST / HTTP/1.0
+            Host: https://webshop.example.org/payments/webhook
+            Via: 1.1 tinyproxy (tinyproxy/1.8.3)
+            Content-Type: application/x-www-form-urlencoded
+            Accept: */*
+            Accept-Encoding: deflate, gzip
+            Content-Length: 16
+            id=tr_d0b0E3EA3v
+
 It might seem a little cumbersome that we don't post the new status immediately, but :doc:`proper security </guides/security>`
 dictates this flow. Since the status is not transmitted in the webhook, fake calls to your webhook will never result in
 orders being processed without being actually paid.

--- a/source/guides/webhooks.rst
+++ b/source/guides/webhooks.rst
@@ -17,7 +17,7 @@ and act accordingly. If the new payment status is ``paid`` you can start shippin
       :linenos:
 
       POST /payments/webhook HTTP/1.0
-      Host: https://webshop.example.org
+      Host: webshop.example.org
       Via: 1.1 tinyproxy (tinyproxy/1.8.3)
       Content-Type: application/x-www-form-urlencoded
       Accept: */*


### PR DESCRIPTION
Add an example code block for fetching webhook headers after making API payment request. 