### PR TITLE
Add missing `resource` prop to Chargeback page

### DIFF
--- a/source/reference/v2/chargebacks-api/get-chargeback.rst
+++ b/source/reference/v2/chargebacks-api/get-chargeback.rst
@@ -36,6 +36,12 @@ Response
 .. list-table::
    :widths: auto
 
+   * - ``resource``
+
+       .. type:: string
+
+     - Indicates the response contains a chargeback object. Will always contain ``chargeback`` for this endpoint.
+
    * - ``id``
 
        .. type:: string


### PR DESCRIPTION
This PR will add the missing `resource` property to the Chargeback page.