### PR TITLE
Chargeback _links.settlement is optional

### DIFF
--- a/source/reference/v2/chargebacks-api/get-chargeback.rst
+++ b/source/reference/v2/chargebacks-api/get-chargeback.rst
@@ -135,6 +135,7 @@ Response
           * - ``settlement``
 
               .. type:: URL object
+                 :required: false
 
             - The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
 


### PR DESCRIPTION
While working on the TypeScript type definitions I noticed that `chargeback._links.settlement` can sometimes be omitted by the API.