### PR TITLE
Add node.js examples

### DIFF
--- a/source/reference/v2/captures-api/get-capture.rst
+++ b/source/reference/v2/captures-api/get-capture.rst
@@ -183,6 +183,19 @@ Example
         payment_id: 'tr_WDqYK6vllg'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const capture = await mollieClient.payments_captures.get(
+          'cpt_4qqhO89gsT',
+          { paymentId: 'tr_WDqYK6vllg' }
+        );
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/captures-api/list-captures.rst
+++ b/source/reference/v2/captures-api/list-captures.rst
@@ -132,6 +132,16 @@ Example
 
       captures = Mollie::Payment::Capture.all(payment_id: 'tr_WDqYK6vllg')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const captures = await mollieClient.payments_captures.list({ paymentId: 'tr_WDqYK6vllg'});
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/chargebacks-api/get-chargeback.rst
+++ b/source/reference/v2/chargebacks-api/get-chargeback.rst
@@ -197,6 +197,19 @@ Example
         payment_id: 'tr_WDqYK6vllg'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async ()  => {
+        const chargeback = await mollieClient.payments_chargebacks.get(
+          'chb_n9z0tp',
+          { paymentId: 'tr_WDqYK6vllg' }
+        );
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -156,6 +156,21 @@ Example
       # (For all chargebacks on the organizations, use an OAuth or Organization access token.)
       chargebacks = Mollie::Chargeback.all
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        // List chargebacks for a single payment
+        const paymentChargebacks = await mollieClient.payments_chargebacks.list({ paymentId: 'tr_WDqYK6vllg' });
+
+        // List chargebacks across all payments on the payment profile
+        // (For all chargebacks on the organizations, use an OAuth or Organization access token.)
+        const chargebacks = await mollieClient.chargebacks.list();
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/create-customer-payment.rst
+++ b/source/reference/v2/customers-api/create-customer-payment.rst
@@ -111,6 +111,26 @@ Example
         webhook_url:   'https://webshop.example.org/payments/webhook/'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const payment = await mollieClient.customers_payments.create({
+          customerId: 'cst_8wmqcHMN4U',
+          amount: {
+            currency: 'EUR',
+            value: '10.00', // We enforce the correct number of decimals through strings
+          },
+          description: 'Order #12345',
+          sequenceType: 'first',
+          redirectUrl: 'https://webshop.example.org/order/12345/',
+          webhookUrl: 'https://webshop.example.org/payments/webhook/',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/create-customer.rst
+++ b/source/reference/v2/customers-api/create-customer.rst
@@ -116,6 +116,19 @@ Example
         email: 'customer@example.org'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const customer = await mollieClient.customers.create({
+          name: 'Customer A',
+          email: 'customer@example.org',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/delete-customer.rst
+++ b/source/reference/v2/customers-api/delete-customer.rst
@@ -66,6 +66,16 @@ Example
 
       Mollie::Customer.delete('cst_8wmqcHMN4U')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const status = mollie.customers.delete('cst_8wmqcHMN4U');
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/get-customer.rst
+++ b/source/reference/v2/customers-api/get-customer.rst
@@ -168,6 +168,16 @@ Example
 
       customer = Mollie::Customer.get('cst_8wmqcHMN4U')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const customer = await mollie.customers.get('cst_kEn1PlbGa');
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/list-customer-payments.rst
+++ b/source/reference/v2/customers-api/list-customer-payments.rst
@@ -57,6 +57,16 @@ Example
 
       payments = Mollie::Customer::Payment.all(customer_id: 'cst_8wmqcHMN4U')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const customerPayments = await mollie.customers_payments.list({ customerId: 'cst_8wmqcHMN4U' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/list-customers.rst
+++ b/source/reference/v2/customers-api/list-customers.rst
@@ -150,6 +150,20 @@ Example
 
       customers = Mollie::Customer.all
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        // First page
+        const customers = await mollie.customers.page();
+
+        // Next page
+        const nextPage = await customers.nextPage();
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/customers-api/update-customer.rst
+++ b/source/reference/v2/customers-api/update-customer.rst
@@ -116,6 +116,20 @@ Example
         email: 'updated-customer@example.org'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const updatedCustomer = await mollie.customers.update({
+          customerId: 'cst_8wmqcHMN4U',
+          name: 'Updated Customer A',
+          email: 'updated-customer@example.org',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -142,6 +142,24 @@ Example
         mandate_reference: 'YOUR-COMPANY-MD13804'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const mandate = await mollieClient.customers_mandates.create({
+          customerId: 'cst_4qqhO89gsT',
+          method: 'directdebit',
+          consumerName: 'John Doe',
+          consumerAccount: 'NL55INGB0000000000',
+          consumerBic: 'INGBNL2A',
+          signatureDate: '2018-05-07',
+          mandateReference: 'YOUR-COMPANY-MD13804',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/mandates-api/get-mandate.rst
+++ b/source/reference/v2/mandates-api/get-mandate.rst
@@ -221,6 +221,19 @@ Example
 
       mandate = Mollie::Customer::Mandate.get('mdt_h3gAaD5zP', customer_id: 'cst_4qqhO89gsT')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const mandate = await mollieClient.customers_mandates.get(
+          'mdt_h3gAaD5zP',
+          { customerId: 'cst_4qqhO89gsT' }
+        );
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/mandates-api/list-mandates.rst
+++ b/source/reference/v2/mandates-api/list-mandates.rst
@@ -148,6 +148,16 @@ Example
       customer = Mollie::Customer.get('cst_stTC2WHAuS')
       mandates = customer.mandates
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const mandates = await mollieClient.customers_mandates.page({ customerId: 'cst_stTC2WHAuS' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/mandates-api/revoke-mandate.rst
+++ b/source/reference/v2/mandates-api/revoke-mandate.rst
@@ -70,6 +70,19 @@ Example
 
       Mollie::Customer::Mandate.delete('mdt_pWUnw6pkBN', customer_id: 'cst_stTC2WHAuS')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const status = await mollieClient.customers_mandates.delete(
+          'mdt_pWUnw6pkBN',
+          { customerId: 'cst_stTC2WHAuS' }
+        );
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/methods-api/get-method.rst
+++ b/source/reference/v2/methods-api/get-method.rst
@@ -231,6 +231,16 @@ Example
 
       Mollie::Method.get('ideal', include: 'issuers,pricing')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const method = await mollieClient.methods.get('ideal', { include: ['issuers', 'pricing'] });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/methods-api/list-methods.rst
+++ b/source/reference/v2/methods-api/list-methods.rst
@@ -231,6 +231,20 @@ Example
       # Methods for the Orders API
       methods = Mollie::Method.all(resource: 'orders')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        // Methods for the Payments API
+        let methods = await mollieClient.methods.all();
+
+        // Methods for the Orders API
+        methods = await mollieClient.methods.all({ resource: 'orders' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/cancel-order-lines.rst
+++ b/source/reference/v2/orders-api/cancel-order-lines.rst
@@ -193,6 +193,23 @@ Example
 
       updated_order = Mollie::Order.get('ord_8wmqcHMN4U')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const updatedOrder = await mollieClient.orders_lines.cancel({
+          lines: [
+            {
+              id: 'odl_dgtxyl',
+              quantity: 1,  // you can partially cancel the line.
+            }
+          ]
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -89,6 +89,16 @@ Example
 
       Mollie::Order.cancel('ord_8wmqcHMN4U')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const canceledOrder = await mollieClient.orders.cancel('ord_8wmqcHMN4U');
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/create-order-payment.rst
+++ b/source/reference/v2/orders-api/create-order-payment.rst
@@ -137,6 +137,24 @@ Example
           // ... redirect the customer to the checkout url
       }
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const payment = await mollieClient.orders_payments.create({
+            orderId: 'ord_stTC2WHAuS',
+            method: 'banktransfer',
+            dueDate: '2018-12-21',
+        });
+
+        if (payment.checkoutUrl) {
+          // ... redirect the customer to the checkout url
+        }
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/create-order-refund.rst
+++ b/source/reference/v2/orders-api/create-order-refund.rst
@@ -191,6 +191,23 @@ Example
       # Alternative shorthand for refunding all eligible order lines
       order.refund!
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const updatedOrder = await mollieClient.orders_refunds.create({
+          orderId: 'ord_stTC2WHAuS',
+          lines: {
+            id: 'odl_dgtxyl',
+            quantity: 1,
+          },
+          description: 'Required quantity not in stock, refunding one photo book.',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -841,6 +841,105 @@ Example
         ]
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const order = await mollieClient.orders.create({
+          amount: {
+            value: '1027.99',
+            currency: 'EUR',
+          },
+          billingAddress: {
+            organizationName: 'Mollie B.V.',
+            streetAndNumber: 'Keizersgracht 313',
+            city: 'Amsterdam',
+            region: 'Noord-Holland',
+            postalCode: '1234AB',
+            country: 'NL',
+            title: 'Dhr.',
+            givenName: 'Piet',
+            familyName: 'Mondriaan',
+            email: 'piet@mondriaan.com',
+            phone: '+31309202070',
+          },
+          shippingAddress: {
+            organizationName: 'Mollie B.V.',
+            streetAndNumber: 'Prinsengracht 313',
+            streetAdditional: '4th floor',
+            city: 'Haarlem',
+            region: 'Noord-Holland',
+            postalCode: '5678AB',
+            country: 'NL',
+            title: 'Mr.',
+            givenName: 'Chuck',
+            familyName: 'Norris',
+            email: 'norris@chucknorrisfacts.net',
+          },
+          metadata: {
+            order_id: '1337',
+            description: 'Lego cars',
+          },
+          consumerDateOfBirth: '1958-01-31',
+          locale: 'nl_NL',
+          orderNumber: '1337',
+          redirectUrl: 'https://example.org/redirect',
+          webhookUrl: 'https://example.org/webhook',
+          method: 'klarnapaylater',
+          lines: [
+            {
+              type: 'physical',
+              sku: '5702016116977',
+              name: 'LEGO 42083 Bugatti Chiron',
+              productUrl: 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
+              imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
+              quantity: 2,
+              vatRate: '21.00',
+              unitPrice: {
+                currency: 'EUR',
+                value: '399.00',
+              },
+              totalAmount: {
+                currency: 'EUR',
+                value: '698.00',
+              },
+              discountAmount: {
+                currency: 'EUR',
+                value: '100.00',
+              },
+              vatAmount: {
+                currency: 'EUR',
+                value: '121.14',
+              },
+            },
+            {
+              type: 'physical',
+              sku: '5702015594028',
+              name: 'LEGO 42056 Porsche 911 GT3 RS',
+              productUrl: 'https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056',
+              imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$',
+              quantity: 1,
+              vatRate: '21.00',
+              unitPrice: {
+                currency: 'EUR',
+                value: '329.99',
+              },
+              totalAmount: {
+                currency: 'EUR',
+                value: '329.99',
+              },
+              vatAmount: {
+                currency: 'EUR',
+                value: '57.27',
+              },
+            },
+          ],
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. _create-order-response:

--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -591,6 +591,16 @@ Example
 
       order = Mollie::Order.get('ord_stTC2WHAuS')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const order = await mollieClient.orders.get('ord_stTC2WHAuS');
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/list-order-refunds.rst
+++ b/source/reference/v2/orders-api/list-order-refunds.rst
@@ -164,6 +164,16 @@ Example
 
       refunds = Order::Refund.all(order_id: 'ord_stTC2WHAuS')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const refunds = await mollieClient.orders_refunds.all({ orderId: 'ord_stTC2WHAuS' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/list-orders.rst
+++ b/source/reference/v2/orders-api/list-orders.rst
@@ -164,6 +164,17 @@ Example
 
       orders = Mollie::Order.all
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const mostRecentOrders = await mollieClient.orders.page();
+        const previousOrders = await mostRecentOrders.nextPage();
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -169,6 +169,30 @@ Example
         }
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const order = await mollieClient.orders.update('ord_kEn1PlbGa', {
+           billingAddress: {
+             organizationName: 'Mollie B.V.',
+             streetAndNumber: 'Keizersgracht 313',
+             city: 'Amsterdam',
+             region: 'Noord-Holland',
+             postalCode: '1234AB',
+             country: 'NL',
+             title: 'Dhr',
+             givenName: 'Piet',
+             familyName: 'Mondriaan',
+             email: 'piet@mondriaan.com',
+             phone: '+31208202070',
+          },
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/orders-api/update-orderline.rst
+++ b/source/reference/v2/orders-api/update-orderline.rst
@@ -199,6 +199,21 @@ Example
                }
          }'
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const updatedOrders = await mollieClient.orders_lines.update('odl_dgtxyl', {
+          orderId: 'ord_pbjz8x',
+          name: 'LEGO 71043 Hogwarts™ Castle',
+          productUrl: 'https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043',
+          imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/payments-api/cancel-payment.rst
+++ b/source/reference/v2/payments-api/cancel-payment.rst
@@ -81,6 +81,16 @@ Example
 
       canceled_payment = Mollie::Payment.cancel('tr_WDqYK6vllg')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const canceledPayment = await mollieClient.payments.delete('tr_Eq8xzWUPA4');
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -696,6 +696,27 @@ Example
         }
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const payment = await mollieClient.payments.create({
+          amount: {
+            currency: 'EUR',
+            value: '10.00', // We enforce the correct number of decimals through strings
+          },
+          description: 'My first payment',
+          redirectUrl: 'https://webshop.example.org/order/12345/',
+          webhookUrl: 'https://webshop.example.org/payments/webhook/',
+          metadata: {
+            order_id: '12345',
+          },
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -1245,6 +1245,16 @@ Example
 
       payment = Mollie::Payment.get('tr_WDqYK6vllg')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const payment = await mollieClient.payments.get('tr_Eq8xzWUPA4');
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/payments-api/list-payments.rst
+++ b/source/reference/v2/payments-api/list-payments.rst
@@ -189,6 +189,19 @@ Example
 
       payments = Mollie::Payment.all
 
+      # get the next page
+      next_payments = payments.next
+
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const payments = await mollieClient.payments.list();
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/refunds-api/cancel-refund.rst
+++ b/source/reference/v2/refunds-api/cancel-refund.rst
@@ -74,6 +74,16 @@ Example
       payment = mollie_client.payments.get('tr_WDqYK6vllg')
       refund = mollie_client.payment_refunds.on(payment).delete('re_4qqhO89gsT')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const status = await mollieClient.payments_refunds.cancel('re_4qqhO89gsT', { paymentId: 'tr_WDqYK6vllg' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/refunds-api/create-refund.rst
+++ b/source/reference/v2/refunds-api/create-refund.rst
@@ -164,6 +164,22 @@ Example
         description: 'Example refund description'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const refund = await mollieClient.payments_refunds.create({
+          paymentId: 'tr_WDqYK6vllg',
+          amount: {
+            value: '5.95',
+            currency: 'EUR',
+          },
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/refunds-api/get-refund.rst
+++ b/source/reference/v2/refunds-api/get-refund.rst
@@ -265,6 +265,16 @@ Example
         payment_id: 'tr_WDqYK6vllg'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const refund = await mollieClient.payments_refunds.get('re_4qqhO89gsT', { paymentId: 'tr_WDqYK6vllg' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/refunds-api/list-refunds.rst
+++ b/source/reference/v2/refunds-api/list-refunds.rst
@@ -184,6 +184,16 @@ Example
 
       refunds = Mollie::Payment.get('tr_7UhSN1zuXS').refunds
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const refunds = await mollieClient.payments_refunds.page({ paymentId: 'tr_WDqYK6vllg' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/shipments-api/create-shipment.rst
+++ b/source/reference/v2/shipments-api/create-shipment.rst
@@ -257,6 +257,46 @@ Example
         }
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        let shipment = await mollieClient.orders_shipments.create({
+          orderId: 'ord_kEn1PlbGa',
+          lines: [
+            {
+              id: 'odl_dgtxyl',
+              quantity: 1,  // you can set the quantity if not all is shipped at once
+            },
+            {
+              id: 'odl_jp31jz',  // all is shipped if no quantity is set
+            },
+          ],
+          tracking: {
+            carrier: 'PostNL',
+            code: '3SKABA000000000',
+            url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C',
+          },
+        });
+
+        // If all lines are shipped, there is no need to specify them:
+        shipment = await mollieClient.orders_shipments.create({
+          orderId: 'ord_kEn1PlbGa',
+          lines: [],
+          tracking: {
+            carrier: 'PostNL',
+            code: '3SKABA000000000',
+            url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C',
+          },
+        });
+      })();
+
+      // Or when no tracking is specified:
+      shipment = await mollieClient.orders_shipments.create({ orderId: 'ord_kEn1PlbGa', lines: [] });
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/shipments-api/get-shipment.rst
+++ b/source/reference/v2/shipments-api/get-shipment.rst
@@ -173,6 +173,18 @@ Example
         order_id: 'ord_kEn1PlbGa'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const shipment = await mollieClient.orders_shipments.get('shp_3wmsgCJN4U', {
+          orderId: 'ord_kEn1PlbGa',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/shipments-api/list-shipments.rst
+++ b/source/reference/v2/shipments-api/list-shipments.rst
@@ -125,6 +125,16 @@ Example
 
       shipments = Mollie::Order::Shipment.all(order_id: 'ord_kEn1PlbGa')
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const shipments = await mollieClient.orders_shipments.all({ orderId: 'ord_kEn1PlbGa' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/shipments-api/update-shipment.rst
+++ b/source/reference/v2/shipments-api/update-shipment.rst
@@ -144,6 +144,22 @@ Example
         }
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const updatedOrder = await mollieClient.orders_shipments.update('', {
+          tracking: {
+            carrier: 'PostNL',
+            code: '3SKABA000000000',
+            url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C',
+          },
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: http

--- a/source/reference/v2/subscriptions-api/cancel-subscription.rst
+++ b/source/reference/v2/subscriptions-api/cancel-subscription.rst
@@ -75,6 +75,16 @@ Example
         customer_id: 'cst_stTC2WHAuS'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const status = await mollieClient.customers_subscriptions.cancel('sub_rVKGtNd6s3', { customerId: 'cst_stTC2WHAuS' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: json

--- a/source/reference/v2/subscriptions-api/create-subscription.rst
+++ b/source/reference/v2/subscriptions-api/create-subscription.rst
@@ -218,6 +218,26 @@ Example
         webhook_url: 'https://webshop.example.org/subscriptions/webhook/'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const subscription = await mollieClient.customers_subscriptions.create({
+          customerId: '',
+          amount: {
+            currency: 'EUR',
+            value: '25.00',
+          },
+          times: 4,
+          interval: '3 months',
+          description: 'Quarterly payment',
+          webhookUrl: 'https://webshop.example.org/subscriptions/webhook/',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: json

--- a/source/reference/v2/subscriptions-api/get-subscription.rst
+++ b/source/reference/v2/subscriptions-api/get-subscription.rst
@@ -239,6 +239,16 @@ Example
         customer_id: 'cst_stTC2WHAuS'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const subscription = await mollieClient.customers_subscriptions.get('sub_rVKGtNd6s3', { customerId: 'cst_stTC2WHAuS' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: json

--- a/source/reference/v2/subscriptions-api/list-subscriptions-payments.rst
+++ b/source/reference/v2/subscriptions-api/list-subscriptions-payments.rst
@@ -128,6 +128,19 @@ Request
    curl -X GET https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K \
        -H "Authorization: Bearer live_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const payments = await mollieClient.customers_subscriptions_payments.all({
+          customerId: 'cst_8wmqcHMN4U',
+          subscriptionId: 'sub_8JfGzs6v3K',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: json

--- a/source/reference/v2/subscriptions-api/list-subscriptions-payments.rst
+++ b/source/reference/v2/subscriptions-api/list-subscriptions-payments.rst
@@ -122,11 +122,13 @@ Example
 
 Request
 ^^^^^^^
-.. code-block:: bash
-   :linenos:
 
-   curl -X GET https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K \
-       -H "Authorization: Bearer live_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+.. code-block-selector::
+   .. code-block:: bash
+      :linenos:
+
+      curl -X GET https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K \
+         -H "Authorization: Bearer live_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
    .. code-block:: javascript
       :linenos:

--- a/source/reference/v2/subscriptions-api/list-subscriptions.rst
+++ b/source/reference/v2/subscriptions-api/list-subscriptions.rst
@@ -156,6 +156,16 @@ Example
       customer = Mollie::Customer.get('cst_8wmqcHMN4U')
       subscriptions = customer.subscriptions
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const subscriptions = await mollieClient.customers_subscriptions.all({ customerId: 'cst_8wmqcHMN4U' });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: json

--- a/source/reference/v2/subscriptions-api/update-subscription.rst
+++ b/source/reference/v2/subscriptions-api/update-subscription.rst
@@ -177,6 +177,26 @@ Example
         webhook_url: 'https://example.org/webhook'
       )
 
+   .. code-block:: javascript
+      :linenos:
+
+      const mollie = require('@mollie/api-client');
+      const mollieClient = mollie({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+      (async () => {
+        const updatedSubscription = await mollieClient.customers_subscriptions.update('sub_8EjeBVgtEn', {
+          customerId: 'cst_8wmqcHMN4U',
+          amount: {
+            currency: 'EUR',
+            value: '10.00',
+          },
+          times: 42,
+          startDate: '2018-12-12',
+          description: 'Mollie recurring subscription',
+          webhookUrl: 'https://example.org/webhook',
+        });
+      })();
+
 Response
 ^^^^^^^^
 .. code-block:: json


### PR DESCRIPTION
This PR adds the Payments API + Orders API node.js examples to the documentation

Requires:
- [ ]  https://github.com/mollie/mollie-api-node/pull/97 to be merged first