### PR TITLE
Get Order: `amountCaptured` is optional in response

### DIFF
--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -88,6 +88,7 @@ Response
    * - ``amountCaptured``
 
        .. type:: amount object
+          :required: false
 
      - The amount captured, thus far. The captured amount will be settled to your account.
 


### PR DESCRIPTION
An order with status `created` does not have the `amountCaptured` field.