### PR TITLE
Get Order: `amountRefunded` is optional in response

### DIFF
--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -97,6 +97,7 @@ Response
    * - ``amountRefunded``
 
        .. type:: amount object
+          :required: false
 
      - The total amount refunded, thus far.
 


### PR DESCRIPTION
An order with the status `created` does not have the `amountRefunded` field.