### PR TITLE
Add token lifetimes to docs

### DIFF
--- a/source/oauth/getting-started.rst
+++ b/source/oauth/getting-started.rst
@@ -38,7 +38,7 @@ Working with access tokens
 --------------------------
 The merchant will be redirected back to your app, along with an auth code. With the auth code, you can retrieve an
 *access token* using default OAuth library functionality. Note access tokens are time limited - you need to refresh them
-periodically using the *refresh token*.
+periodically using the *refresh token*. An acces token expires afer 1 hour. A refresh token does not expire.
 
 Have merchants start using your app
 -----------------------------------


### PR DESCRIPTION
There was no mention of the lifetimes of the access and refresh token in the api documentation.

This seemed the most logical place to add this info.