### PR TITLE
Fix PHP example for payment method that can't be enabled

### DIFF
--- a/source/reference/v2/profiles-api/enable-method.rst
+++ b/source/reference/v2/profiles-api/enable-method.rst
@@ -120,7 +120,7 @@ Request (method that can't be enabled)
       $profile = $mollie->profiles->get('pfl_v9hTwCvYqw'));
 
       try {
-          $profile->enableMethod('bancontact');
+          $profile->enableMethod('creditcard');
       } catch (ApiException $e) {
           $dashboardUrl = $e->getDashboardUrl();
 


### PR DESCRIPTION
The PHP example for a payment method that can't be enabled showed the wrong value