### PR TITLE
Remove `Set Fees` endpoint from the sidebar navigation.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -65,6 +65,9 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
+# Add the pathname of pages you want to prevent from being indexed by search engines here.
+do_not_index = ['reference/reseller-api/endpoints/set-fees']
+
 # The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
@@ -76,6 +79,7 @@ html_context = {
     'github_user': 'mollie',
     'github_repo': 'api-documentation',
     'github_version': 'master/source/',
+    'do_not_index': do_not_index,
 }
 
 html_logo = '_static/img/mollie-logo.png'

--- a/source/conf.py
+++ b/source/conf.py
@@ -30,7 +30,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = 'Mollie API'
-copyright = '2018, Mollie B.V. <info@mollie.com>'
+copyright = '2019, Mollie B.V. <info@mollie.com>'
 author = 'Mollie B.V. <info@mollie.com>'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/source/theme/layout.html
+++ b/source/theme/layout.html
@@ -12,6 +12,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  {% if pagename in do_not_index %}
+    <meta name="robots" content="noindex" />
+  {% endif %}
   {% if versionName %}
     <title>{{ title|striptags|e }} &mdash; API {{ versionName }} documentation &mdash; Mollie</title>
   {% else %}

--- a/source/theme/sidebar-reseller-api.html
+++ b/source/theme/sidebar-reseller-api.html
@@ -72,11 +72,12 @@
         'Get profiles',
         'POST /api/reseller/v1/profiles'
         ) }}
-        {{ sidebar_item(
-        'reference/reseller-api/endpoints/set-fees',
-        'Set fees',
-        'POST /api/reseller/v1/set-fees'
-        ) }}
+        {# 
+            The Set Fees endpoint is omitted from this list on purpose. It’s still accessible 
+            directly at https://docs.mollie.com/reference/reseller-api/endpoints/set-fees.
+
+            See https://mollie.atlassian.net/browse/ONB-170 for more details.
+        #}
     </ul>
 </div>
 


### PR DESCRIPTION
According to our sales department, this endpoint is only accessible for a handful of partners. They would like to hide it from the navigation to avoid confusing regular resellers who think this functionality will be available to them.