### PR TITLE
Add parameter anchor links

### DIFF
--- a/source/extensions/mollie/param_name_directive.py
+++ b/source/extensions/mollie/param_name_directive.py
@@ -1,0 +1,34 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+
+
+class ParamNameDirective(Directive):
+    has_content = False
+    optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {
+        "prefix": directives.unchanged_required
+    }
+
+    def run(self):
+        param_name = self.arguments[0]
+        param_anchor_text = self.get_param_anchor_text(param_name)
+
+        container = nodes.container()
+        container["ids"].append(param_anchor_text)
+
+        param_name_node = nodes.literal(text=param_name)
+        container.append(param_name_node)
+
+        return [container]
+
+    def get_param_anchor_text(self, param_name):
+        prefix = self.options.get("prefix", None)
+        if prefix is None:
+            anchor_text = "parameter-{}".format(param_name)
+        else:
+            anchor_text = "parameter-{}-{}".format(prefix, param_name)
+
+        return anchor_text\
+            .replace(" ", "-")\
+            .replace("_", "-")

--- a/source/extensions/mollie/setup.py
+++ b/source/extensions/mollie/setup.py
@@ -3,6 +3,7 @@ from .api_endpoint_directive import ApiEndpointDirective
 from .authentication_directive import AuthenticationDirective
 from .code_block_selector_directive import CodeBlockSelectorDirective
 from .data_type_directive import DataTypeDirective
+from .param_name_directive import ParamNameDirective
 
 
 def setup(app):
@@ -16,6 +17,7 @@ def setup(app):
     app.add_directive('authentication', AuthenticationDirective)
     app.add_directive('code-block-selector', CodeBlockSelectorDirective)
     app.add_directive('type', DataTypeDirective)
+    app.add_directive('param-name', ParamNameDirective)
 
     # When debugging, it is best to disable parallel reading and writing.
     return {

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -28,7 +28,7 @@ Parameters
 .. list-table::
    :widths: auto
 
-   * - ``amount``
+   * - .. param-name:: amount
 
        .. type:: amount object
           :required: true
@@ -39,7 +39,7 @@ Parameters
        .. list-table::
           :widths: auto
 
-          * - ``currency``
+          * - .. param-name:: currency
 
               .. type:: string
                  :required: true
@@ -182,7 +182,8 @@ Bank transfer
 .. list-table::
    :widths: auto
 
-   * - ``billingEmail``
+   * - .. param-name:: billingEmail
+          :prefix: bankTransfer
 
        .. type:: string
           :required: false

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -95,7 +95,7 @@ Parameters
           `ngrok <https://lornajane.net/posts/2015/test-incoming-webhooks-locally-with-ngrok>`_ to have the webhooks
           delivered to your local machine.
 
-   * - ``locale``
+   * - .. param-name:: locale
 
        .. type:: string
           :required: false


### PR DESCRIPTION
As requested in issue #420, this PR adds parameter-level anchor links. This is done by adding a new custom directive for the parameter name. It adds an id to the container in which the parameter name resides, and allows for specifying a prefix, such that parameters with identical names can still be referred to uniquely.

To put this into practice, instead of this:
```
* - ``amount``
```
We can now use this:
```
* - .. param-name:: amount
```
Which results in the `#parameter-amount` anchor tag to link to the amount parameter.

As mentioned, you can add a prefix to uniquely identify parameters that occur multiple times on the same page, such as `billingEmail`, like so:
```
* - .. param-name:: billingEmail
       :prefix: bankTransfer
```
Which results in the `#parameter-bankTransfer-billingEmail` anchor tag to link to the `billingEmail` parameter under the bank transfer section.

**Please note**:
- For now, I've only added the new syntax to three parameters. I'd like to get feedback on this, and if it's good to go, we can do a bulk search and replace to apply it everywhere. Prefixes will have to be added manually, I think.
- We will probably need to make some modifications on the front end to allow end users to easily copy this anchor link, just like for the headers on each page.