### PR TITLE
Fixes flickering links and code block selector depending on example id

### DIFF
--- a/source/theme/styles/components/_code-example.scss
+++ b/source/theme/styles/components/_code-example.scss
@@ -1,8 +1,11 @@
 .rst-content #example {
   max-width: 700px;
-   @media (min-width: breakpoint('extra-large')) {
-      max-width: 846px;
-   }
+  @media (min-width: breakpoint('extra-large')) {
+    max-width: 846px;
+  }
+}
+
+.rst-content {
   .examples-switcher {
     .example-switch {
       font-weight: 300;
@@ -19,8 +22,6 @@
       &:hover,
       &:focus {
         color: $brand-primary-hover;
-        text-decoration: none;
-        border-bottom: none;
       }
 
       &.is-selected {


### PR DESCRIPTION
Fixes https://github.com/mollie/api-documentation/issues/411
And enables https://github.com/mollie/api-documentation/pull/421

If the example id is not exactly `example` we can't really style it (add the `max-width`) so that the scroll bars don't appear.
But at least now the style won't break.