### PR TITLE
Add missing failure reasons

### DIFF
--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -808,7 +808,7 @@ Credit card
 
               Possible values: ``invalid_card_number`` ``invalid_cvv`` ``invalid_card_holder_name`` ``card_expired``
               ``invalid_card_type`` ``refused_by_issuer`` ``insufficient_funds`` ``inactive_card`` ``unknown_reason``
-              ```possible_fraud```
+              ``possible_fraud``
 
 Gift cards
 """"""""""

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -807,7 +807,8 @@ Credit card
             - Only available for failed payments. Contains a failure reason code.
 
               Possible values: ``invalid_card_number`` ``invalid_cvv`` ``invalid_card_holder_name`` ``card_expired``
-              ``invalid_card_type`` ``refused_by_issuer`` ``insufficient_funds`` ``inactive_card``
+              ``invalid_card_type`` ``refused_by_issuer`` ``insufficient_funds`` ``inactive_card`` ``unknown_reason``
+              ```possible_fraud```
 
 Gift cards
 """"""""""


### PR DESCRIPTION
Two credit card failure reasons were missing in the docs. Added them.