### PR TITLE
Fix typos in PHP example

### DIFF
--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -556,7 +556,7 @@ Example
                   "currency" => "EUR"
             ],
             "billingAddress" => [
-                  "organizationName": "Mollie B.V.",
+                  "organizationName" => "Mollie B.V.",
                   "streetAndNumber" => "Keizersgracht 313",
                   "city" => "Amsterdam",
                   "region" => "Noord-Holland",
@@ -598,7 +598,7 @@ Example
                   "name" => "LEGO 42083 Bugatti Chiron",
                   "productUrl" => "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
                   "imageUrl" => 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
-                  "metadata": [
+                  "metadata" => [
                      "order_id" => "1337",
                      "description" => "Bugatti Chiron"
                   ],


### PR DESCRIPTION
Fix typos in PHP example