### PR TITLE
Get Payment: clarify settlement amount

### DIFF
--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -309,7 +309,8 @@ Response
      -   This optional field will contain the amount that will be settled to your account, converted to the currency
          your account is settled in. It follows the same syntax as the ``amount`` property.
 
-         Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal or gift cards.
+         Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal or gift cards. If no 
+         amount is settled by Mollie the ``settlementAmount`` is omitted from the response.
 
    * - ``settlementId``
 


### PR DESCRIPTION
Integrator was confused why the settlementAmount was missing for a payment. Clarified our API documentation.