### PR TITLE
Add uniqueness comment to mandateReferences

### DIFF
--- a/source/reference/v1/mandates-api/create-mandate.rst
+++ b/source/reference/v1/mandates-api/create-mandate.rst
@@ -76,8 +76,8 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
        .. type:: date
           :required: false
 
-     - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
-       Direct Debit payment if the ``mandateReference``is not unique.
+     - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a Direct Debit payment if
+       the ``mandateReference`` is not unique.
 
 
 Access token parameters

--- a/source/reference/v1/mandates-api/create-mandate.rst
+++ b/source/reference/v1/mandates-api/create-mandate.rst
@@ -77,7 +77,7 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
           :required: false
 
      - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
-     Direct Debit payment if the ``mandateReference``is not unique.
+       Direct Debit payment if the ``mandateReference``is not unique.
 
 
 Access token parameters

--- a/source/reference/v1/mandates-api/create-mandate.rst
+++ b/source/reference/v1/mandates-api/create-mandate.rst
@@ -76,7 +76,9 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
        .. type:: date
           :required: false
 
-     - A custom mandate reference.
+     - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
+     Direct Debit payment if the ``mandateReference``is not unique.
+
 
 Access token parameters
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -70,7 +70,7 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
           :required: false
 
      - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
-       Direct Debit payment if the ``mandateReference``is not unique.
+       Direct Debit payment if the ``mandateReference`` is not unique.
 
 
 Access token parameters

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -69,7 +69,8 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
        .. type:: string
           :required: false
 
-     - A custom mandate reference.
+     - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
+     Direct Debit payment if the ``mandateReference``is not unique.
 
 Access token parameters
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -70,7 +70,7 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
           :required: false
 
      - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
-     Direct Debit payment if the ``mandateReference``is not unique.
+       Direct Debit payment if the ``mandateReference``is not unique.
 
 
 Access token parameters

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -71,6 +71,7 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
 
      - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
      Direct Debit payment if the ``mandateReference``is not unique.
+     
 
 Access token parameters
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -71,7 +71,7 @@ Replace ``customerId`` in the endpoint URL by the customer's ID, for example ``/
 
      - A custom mandate reference. Use an unique ``mandateReference`` as some banks decline a
      Direct Debit payment if the ``mandateReference``is not unique.
-     
+
 
 Access token parameters
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There are at least two banks that decline SDD payments if the same mandate reference is used with multiple IBANs. Added this information to make ensure these preventable declines do not happen.