### PR TITLE
Changed the PHP and Python examples for canceling a refund

### DIFF
--- a/source/reference/v2/refunds-api/cancel-refund.rst
+++ b/source/reference/v2/refunds-api/cancel-refund.rst
@@ -61,7 +61,7 @@ Example
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
 
       $refund = $mollie->payments->get("tr_WDqYK6vllg")->getRefund("re_4qqhO89gsT");
-      $canceledRefund = $refund->cancel();
+      $refund->cancel();
 
    .. code-block:: python
       :linenos:
@@ -72,7 +72,7 @@ Example
       mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
 
       payment = mollie_client.payments.get('tr_WDqYK6vllg')
-      refund = mollie_client.payment_refunds.on(payment).delete('re_4qqhO89gsT')
+      mollie_client.payment_refunds.on(payment).delete('re_4qqhO89gsT')
 
 Response
 ^^^^^^^^


### PR DESCRIPTION
Fixes #497.

In both the PHP and Python clients, the cancel and refund functions (respectively) don't actually return anything. See [Refund.php](https://github.com/mollie/mollie-api-php/blob/501d45b140c64f4a6f3dc24eff118a41413ad5bc/src/Resources/Refund.php#L126:L141) and [base.py](https://github.com/mollie/mollie-api-python/blob/9b1cd0df30a5bc744c91ad1f915712f2846a41cb/mollie/api/resources/base.py#L52).