### PR TITLE
Fix cURL example

### DIFF
--- a/source/reference/v2/subscriptions-api/list-subscriptions-payments.rst
+++ b/source/reference/v2/subscriptions-api/list-subscriptions-payments.rst
@@ -127,7 +127,7 @@ Request
    .. code-block:: bash
       :linenos:
 
-      curl -X GET https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K \
+      curl -X GET https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K/payments \
          -H "Authorization: Bearer live_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
 Response


### PR DESCRIPTION
The cURL example is missing the trailing `/payments` path.