### PR TITLE
OAuth2 Token request parameter descriptions correction.

### DIFF
--- a/source/reference/oauth2/tokens.rst
+++ b/source/reference/oauth2/tokens.rst
@@ -45,10 +45,14 @@ Parameters
    * - ``redirect_uri``
 
        .. type:: string
-          :required: true
+          :required: false
 
      - The URL the merchant is sent back to once the request has been authorized. It must match the URL you set when
        :doc:`registering your app </oauth/getting-started>`.
+
+       .. note::
+          When refreshing a token, this parameter **is** required if the initial ``authorization_code`` contained a
+          ``redirect_uri``.
 
 Response
 --------


### PR DESCRIPTION
The docs states the redirect_uri was required for all `oauth2/token` requests. In reality there's a conditional requirement in token requests using the grant type `refresh_token`. When the initial `authorization_code` request contained a redirect URI, the request to refresh the token should contain the exact same value. A note was added for clarity.