### PR TITLE
Fix typo in SEPA Direct Debit `bankReason` description.

### DIFF
--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -1203,7 +1203,7 @@ SEPA Direct Debit
 
               .. type:: string
 
-            - Only available if the payment has failed – A textual desciption of the failure reason.
+            - Only available if the payment has failed – A textual description of the failure reason.
 
           * - ``endToEndIdentifier``
 


### PR DESCRIPTION
Fixed a little typo in the SEPA Direct Debit `bankReason` description.