### PR TITLE
Change warning on top of page

### DIFF
--- a/source/reference/reseller-api/guides/overview.rst
+++ b/source/reference/reseller-api/guides/overview.rst
@@ -1,8 +1,7 @@
 Reseller API
 ============
 
-.. warning:: The Reseller API has been deprecated and can still be used for the foreseeable future. We recommend to
-             change to the Mollie v2 API.
+.. warning:: The Reseller API has been deprecated. Only selected partners still have access to this legacy functionality. As an     alternative, we recommend using :doc:`Mollie Connect </oauth/overview>` and the :doc:`Mollie v2 API </reference/v2>`.
 
 The **Reseller API** can be used to register new merchants with Mollie, link existing merchants to your reseller account,
 or change settings of merchants that you have referred to Mollie.

--- a/source/reference/reseller-api/guides/overview.rst
+++ b/source/reference/reseller-api/guides/overview.rst
@@ -1,7 +1,7 @@
 Reseller API
 ============
 
-.. warning:: The Reseller API has been deprecated. Only selected partners still have access to this legacy functionality. As an     alternative, we recommend using :doc:`Mollie Connect </oauth/overview>` and the :doc:`Mollie v2 API </reference/v2>`.
+.. warning:: The Reseller API has been deprecated. Only selected partners still have access to this legacy functionality. As an alternative, we recommend using :doc:`Mollie Connect </oauth/overview>` and the :doc:`Mollie v2 API </reference/v2/payments-api/create-payment>`.
 
 The **Reseller API** can be used to register new merchants with Mollie, link existing merchants to your reseller account,
 or change settings of merchants that you have referred to Mollie.


### PR DESCRIPTION
Instead of saying it's still possible to use the Reseller API, we now want to communicate that it is only available for selected partners.