### PR TITLE
Update recurring.rst for subscription case

### DIFF
--- a/source/payments/recurring.rst
+++ b/source/payments/recurring.rst
@@ -52,6 +52,7 @@ periodically through *subscriptions*.
 
    .. note:: For credit card and PayPal payments, you can create a payment with a zero amount which
              means, no money will be debited from the card or account when doing the first payment.
+             If you intend to start a subscription, the amount for the first payment can be the amount you will periodically charge. Next, you can set up a subscription which starts after the first period. (see subscription API, startDate)
 
    .. code-block:: bash
       :linenos:

--- a/source/payments/recurring.rst
+++ b/source/payments/recurring.rst
@@ -23,7 +23,8 @@ In the following sections we explain the following topics.
 * :ref:`Charging periodically with subscriptions <payments/recurring/charging-periodically>`
 * :ref:`How do webhooks for subscriptions work? <payments/recurring/subscription-webhooks>`
 
-For more information on how to test recurring payments, please refer to our :doc:`guide </guides/testing>` for testing the Mollie API.
+For more information on how to test recurring payments, please refer to our :doc:`guide </guides/testing>` for testing
+the Mollie API.
 
 .. _payments/recurring/first-payment:
 
@@ -35,7 +36,8 @@ complete the payment with the account or card that will be used for recurring ch
 payment is completed successfully, the customer's account or card will immediately be chargeable *on-demand*, or
 periodically through *subscriptions*.
 
-#. Create a unique customer using the :doc:`Customers API </reference/v2/customers-api/create-customer>`. If you are using Mollie Connect make sure you have the permission "customers.write" in order to create a customer.
+#. Create a unique customer using the :doc:`Customers API </reference/v2/customers-api/create-customer>`. If you are
+using Mollie Connect, make sure you have the permission `customers.write` in order to create a customer.
 
    .. code-block:: bash
       :linenos:
@@ -50,9 +52,12 @@ periodically through *subscriptions*.
 #. Create a payment (or order) for the customer by specifying the ``customerId`` and setting the ``sequenceType``
    parameter to ``first``.
 
-   .. note:: For credit card and PayPal payments, you can create a payment with a zero amount which
-             means, no money will be debited from the card or account when doing the first payment.
-             If you intend to start a subscription, the amount for the first payment can be the amount you will periodically charge. Next, you can set up a subscription which starts after the first period. (see subscription API, startDate)
+   .. note:: For credit card and PayPal payments, you can create a payment with a zero amount. No money will then be
+             debited from the card or account when doing the first payment.
+             If you intend to start a subscription, you can use this payment as the first instalment, e.g. by charging
+             the amount you will periodically charge. Next, you can set up a subscription which starts after the first
+             period. See also the `startDate` field in the
+             :doc:`Subscriptions API </reference/v2/subscriptions-api/create-subscription`.
 
    .. code-block:: bash
       :linenos:
@@ -81,7 +86,8 @@ periodically through *subscriptions*.
 .. note:: Not all payment methods support a first payment. When the ``method`` parameter is not provided in the API, we
           take care of this automatically in our :doc:`Checkout </guides/checkout>`. The following payment methods
           support a first payment and are thus allowed as a value for the ``method`` parameter of a first payment:
-          ``bancontact`` ``belfius`` ``creditcard`` ``eps`` ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``mybank`` ``paypal`` ``sofort``
+          ``bancontact`` ``belfius`` ``creditcard`` ``eps`` ``giropay`` ``ideal`` ``inghomepay`` ``kbc`` ``mybank``
+          ``paypal`` ``sofort``
 
 .. note:: Created mandates are unique to your account and can not be transferred to other accounts.
 

--- a/source/payments/recurring.rst
+++ b/source/payments/recurring.rst
@@ -57,7 +57,7 @@ using Mollie Connect, make sure you have the permission `customers.write` in ord
              If you intend to start a subscription, you can use this payment as the first instalment, e.g. by charging
              the amount you will periodically charge. Next, you can set up a subscription which starts after the first
              period. See also the `startDate` field in the
-             :doc:`Subscriptions API </reference/v2/subscriptions-api/create-subscription`.
+             :doc:`Subscriptions API </reference/v2/subscriptions-api/create-subscription>`.
 
    .. code-block:: bash
       :linenos:


### PR DESCRIPTION
At the moment it's a bit unclear how to handle a subscription model while having to make a first-time payment. The best solution is to charge the customer the amount that will be periodically charged right away. Next, you can set up a subscription which starts after the first period (see subscription API, startDate)