### PR TITLE
added cardholder in example

### DIFF
--- a/source/guides/mollie-components/overview.rst
+++ b/source/guides/mollie-components/overview.rst
@@ -91,10 +91,11 @@ After initializing the Mollie object, you should create the four card holder dat
    :linenos:
 
    <form>
+     <div id="card-holder"></div>
+     <div id="card-holder-error"></div>
+     
      <div id="card-number"></div>
      <div id="card-number-error"></div>
-
-
 
      <div id="expiry-date"></div>
      <div id="expiry-date-error"></div>


### PR DESCRIPTION
The cardholder placeholder was missing in the guide.