### PR TITLE
Add `year` & `month` parameter to clients-list endpoint

### DIFF
--- a/source/reference/v2/partners-api/list-clients.rst
+++ b/source/reference/v2/partners-api/list-clients.rst
@@ -36,6 +36,20 @@ Parameters
 
      - The number of clients to return (with a maximum of 250).
 
+   * - ``year``
+
+       .. type:: integer
+          :required: false
+
+     - Show the statistics for the given year.
+
+   * - ``month``
+
+       .. type:: integer
+          :required: false
+
+     - Show the statistics for the given month.
+
 Embedding of related resources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This endpoint also allows for embedding additional information by appending the following values via


### PR DESCRIPTION
For the endpoint `https://api.mollie.com/v2/clients`, it is possible to add extra parameters to the request. 

For example:
- year: 2020 (`?year=2020`)
- month: 12 (`?month=12`)