### PR TITLE
Label `locale` as optional in `/payments/*` response

### DIFF
--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -310,6 +310,7 @@ Response
    * - ``locale``
 
        .. type:: string
+          :required: false
 
      - The customer's locale, either forced on creation by specifying the ``locale`` parameter, or detected
        by us during checkout. Will be a full locale, for example ``nl_NL``.


### PR DESCRIPTION
Responses from the `/v2/payments/*` endpoint do not always include a `locale` (for example when using Apple Pay in Mollie Checkout and no locale was specified on payment creation), therefore `locale` should have the "Optional" label in the documentation.