### PR TITLE
CC-1240 - Mollie API documentation should mention all the possible credit card failure reasons

### DIFF
--- a/source/guides/mollie-components/handling-errors.rst
+++ b/source/guides/mollie-components/handling-errors.rst
@@ -50,9 +50,10 @@ contain the ``extra`` property with two additional keys:
 
             - Only available for failed payments. Contains a failure reason code.
 
-              Possible values: ``authentication_failed`` ``invalid_card_number`` ``invalid_cvv``
-              ``invalid_card_holder_name`` ``card_expired`` ``invalid_card_type`` ``refused_by_issuer``
-              ``insufficient_funds`` ``inactive_card`` ``unknown_reason`` ``possible_fraud``
+              Possible values: ``authentication_abandoned`` ``authentication_failed`` ``authentication_unavailable_acs``
+              ``card_declined`` ``card_expired`` ``inactive_card`` ``insufficient_funds`` ``invalid_cvv``
+              ``invalid_card_holder_name`` ``invalid_card_number`` ``invalid_card_type`` ``possible_fraud``
+              ``refused_by_issuer`` ``unknown_reason``
 
           * - ``failureMessage``
 
@@ -120,9 +121,10 @@ The reason of the error will be available via the ``details`` object:
 
             - Only available for failed payments. Contains a failure reason code.
 
-              Possible values: ``authentication_failed`` ``invalid_card_number`` ``invalid_cvv``
-              ``invalid_card_holder_name`` ``card_expired`` ``invalid_card_type`` ``refused_by_issuer``
-              ``insufficient_funds`` ``inactive_card`` ``unknown_reason`` ``possible_fraud``
+              Possible values: ``authentication_abandoned`` ``authentication_failed`` ``authentication_unavailable_acs``
+              ``card_declined`` ``card_expired`` ``inactive_card`` ``insufficient_funds`` ``invalid_cvv``
+              ``invalid_card_holder_name`` ``invalid_card_number`` ``invalid_card_type`` ``possible_fraud``
+              ``refused_by_issuer`` ``unknown_reason``
 
           * - ``failureMessage``
 

--- a/source/reference/v1/payments-api/get-payment.rst
+++ b/source/reference/v1/payments-api/get-payment.rst
@@ -253,9 +253,10 @@ Response
 
      - Only available for failed Bancontact and credit card payments. Contains a failure reason code.
 
-       Possible values: ``authentication_failed``  ``card_expired`` ``inactive_card`` ``insufficient_funds``
-       ``invalid_card_holder_name`` ``invalid_card_number`` ``invalid_card_type`` ``invalid_cvv``
-       ``possible_fraud`` ``refused_by_issuer`` ``unknown_reason``
+       Possible values: ``authentication_abandoned`` ``authentication_failed`` ``authentication_unavailable_acs``
+       ``card_declined`` ``card_expired`` ``inactive_card`` ``insufficient_funds`` ``invalid_cvv``
+       ``invalid_card_holder_name`` ``invalid_card_number`` ``invalid_card_type`` ``possible_fraud``
+       ``refused_by_issuer`` ``unknown_reason``
 
    * - ``applicationFee``
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -832,9 +832,10 @@ Credit card
 
             - Only available for failed payments. Contains a failure reason code.
 
-              Possible values: ``authentication_failed`` ``card_declined`` ``card_expired`` ``inactive_card``
-              ``insufficient_funds`` ``invalid_card_holder_name`` ``invalid_card_number`` ``invalid_card_type``
-              ``invalid_cvv`` ``possible_fraud`` ``refused_by_issuer`` ``unknown_reason``
+              Possible values: ``authentication_abandoned`` ``authentication_failed`` ``authentication_unavailable_acs``
+              ``card_declined`` ``card_expired`` ``inactive_card`` ``insufficient_funds`` ``invalid_cvv``
+              ``invalid_card_holder_name`` ``invalid_card_number`` ``invalid_card_type`` ``possible_fraud``
+              ``refused_by_issuer`` ``unknown_reason``
 
           * - ``failureMessage``
 


### PR DESCRIPTION
We recently added the `authentication_unavailable_acs` failure reason, but forgot to update the Mollie API documentation to include this new failure reason.

As part of adding this failure reason, I noticed a couple more failure reasons were not added (everywhere):
- `authentication_abandoned`
- `card_declined`