### PR TITLE
CC-1240 - Update changelogs to mention we added new credit card failure reasons

### DIFF
--- a/source/changelog/v1/changelog.rst
+++ b/source/changelog/v1/changelog.rst
@@ -11,6 +11,11 @@ changes are documented here.
 March 2021
 ==========
 
+Tuesday, 23rd
+-------------
+- Added ``authentication_abandoned``, ``authentication_unavailable_acs`` and ``card_declined`` as possible ``failureReason`` in the
+  :doc:`Payments API</reference/v1/payments-api/get-payment>` for credit card payments.
+
 Tuesday, 16th
 -------------
 - Added ``bloemencadeaukaart`` and ``kluscadeau`` as gift card issuers.

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -10,6 +10,11 @@ No remarkable changes to mention at the moment.
 March 2021
 ==========
 
+Tuesday, 23rd
+-------------
+- Added ``authentication_abandoned`` and ``authentication_unavailable_acs`` as possible ``failureReason`` in the
+  :doc:`Payments API</reference/v2/payments-api/get-payment>` for credit card payments.
+
 Tuesday, 16th
 -------------
 - Added ``bloemencadeaukaart`` and ``kluscadeau`` as gift card issuers.


### PR DESCRIPTION
This is a follow-up to PR #741, to update the changelogs.