### PR TITLE
Refund webhook event clarification

### DIFF
--- a/source/guides/webhooks.rst
+++ b/source/guides/webhooks.rst
@@ -51,7 +51,7 @@ following statuses:
 
 Furthermore, the webhook will be called when:
 
-* A refund is performed on the payment
+* A refund is performed on the payment and the refund reaches status ``failed`` or ``refunded``
 * A chargeback is received on the payment.
 
 Read more about :doc:`payment status changes </payments/status-changes>`.


### PR DESCRIPTION
The refund only triggers the payment webhook on specific status changes