### PR TITLE
Add Python code examples for Payment links.

### DIFF
--- a/source/reference/v2/payment-links-api/create-payment-link.rst
+++ b/source/reference/v2/payment-links-api/create-payment-link.rst
@@ -151,6 +151,24 @@ Example
       ]);
       $paymentLink->getCheckoutUrl();
 
+   .. code-block:: python
+      :linenos:
+
+      from mollie.api.client import Client
+
+      mollie_client = Client()
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+      payment_link = mollie_client.payment_links.create({
+         "amount": {
+               "currency": "EUR",
+               "value": "24.95"
+         },
+         "description": "Bicycle tires",
+         "expiresAt": "2021-06-06T11:00:00+00:00",
+         "webhookUrl": "https://webshop.example.org/payment-links/webhook/",
+         "redirectUrl": "https://webshop.example.org/thanks",
+      })
+
 Response
 ^^^^^^^^
 .. code-block:: none

--- a/source/reference/v2/payment-links-api/get-payment-link.rst
+++ b/source/reference/v2/payment-links-api/get-payment-link.rst
@@ -169,6 +169,15 @@ Example
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
       $paymentLink = $mollie->paymentLinks->get("pl_4Y0eZitmBnQ6IDoMqZQKh");
 
+   .. code-block:: python
+      :linenos:
+
+      from mollie.api.client import Client
+
+      mollie_client = Client()
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+      payment_link = mollie_client.payment_links.get("pl_4Y0eZitmBnQ6IDoMqZQKh")
+
 Response
 ^^^^^^^^
 .. code-block:: none

--- a/source/reference/v2/payment-links-api/list-payment-links.rst
+++ b/source/reference/v2/payment-links-api/list-payment-links.rst
@@ -144,6 +144,15 @@ Example
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
       $paymentLinks = $mollie->paymentLinks->page(null, 5);
 
+   .. code-block:: python
+      :linenos:
+
+      from mollie.api.client import Client
+
+      mollie_client = Client()
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+      payment_links = mollie_client.payment_links.list()
+
 Response
 ^^^^^^^^
 .. code-block:: none


### PR DESCRIPTION
Some simple examples using the Payment links API in python. Payment Links is supported by the Python API client since v2.9.0