### PR TITLE
Update create-order.rst

### DIFF
--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -146,7 +146,7 @@ Parameters
        screen but will only show the methods specified in the array. For example, you can use this functionality to only
        show payment methods from a specific country to your customer ``['bancontact', 'belfius']``.
 
-       Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
+       Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``eps``
        ``giftcard`` ``giropay`` ``ideal`` ``kbc``  ``klarnapaylater`` ``klarnasliceit`` ``mybank``
        ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort`` ``voucher``
 


### PR DESCRIPTION
Remove "Direct debit" at "method" of the orders API, because it cannot be shown in the payment screen. 