### PR TITLE
Updated Node.js examples for 3.6.0

### DIFF
--- a/source/components/overview.rst
+++ b/source/components/overview.rst
@@ -262,19 +262,17 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'live_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const payment = await mollieClient.payments.create({
-          method: 'creditcard',
-          amount: {
-            currency: 'EUR',
-            value: '10.00', // We enforce the correct number of decimals through strings
-          },
-          description: 'Order #12345',
-          redirectUrl: 'https://webshop.example.org/order/12345/',
-          webhookUrl: 'https://webshop.example.org/payments/webhook/',
-          cardToken: 'tkn_UqAvArS3gw'
-        });
-      })();
+      const payment = await mollieClient.payments.create({
+        method: 'creditcard',
+        amount: {
+          currency: 'EUR',
+          value: '10.00'
+        },
+        description: 'Order #12345',
+        redirectUrl: 'https://webshop.example.org/order/12345/',
+        webhookUrl: 'https://webshop.example.org/payments/webhook/',
+        cardToken: 'tkn_UqAvArS3gw'
+      });
 
 Response
 ^^^^^^^^

--- a/source/integration-partners/user-agent-strings.rst
+++ b/source/integration-partners/user-agent-strings.rst
@@ -78,9 +78,9 @@ The code examples below illustrate how the Mollie plugin (v0.9.9) for Magento 2 
 
       const { createMollieClient } = require('@mollie/api-client');
 
-      const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+      const mollieClient = createMollieClient({
         apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM',
-        versionStrings: 'MollieMagento2/0.9.9 Magento/2.1.5'
+        versionStrings: ['MollieMagento2/0.9.9', 'Magento/2.1.5']
       });
 
 If you are using Laravel, check out the ``addVersionString()`` method

--- a/source/reference/v2/captures-api/get-capture.rst
+++ b/source/reference/v2/captures-api/get-capture.rst
@@ -180,12 +180,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const capture = await mollieClient.payments_captures.get(
-          'cpt_4qqhO89gsT',
-          { paymentId: 'tr_WDqYK6vllg' }
-        );
-      })();
+      const capture = await mollieClient.paymentCaptures.get('cpt_4qqhO89gsT', {
+        paymentId: 'tr_WDqYK6vllg'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/captures-api/list-captures.rst
+++ b/source/reference/v2/captures-api/list-captures.rst
@@ -132,9 +132,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const captures = await mollieClient.payments_captures.list({ paymentId: 'tr_WDqYK6vllg'});
-      })();
+      const captures = mollieClient.paymentCaptures.iterate({ paymentId: 'tr_WDqYK6vllg' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/chargebacks-api/get-payment-chargeback.rst
+++ b/source/reference/v2/chargebacks-api/get-payment-chargeback.rst
@@ -205,12 +205,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async ()  => {
-        const chargeback = await mollieClient.payments_chargebacks.get(
-          'chb_n9z0tp',
-          { paymentId: 'tr_WDqYK6vllg' }
-        );
-      })();
+      const chargeback = await mollieClient.paymentChargebacks.get('chb_n9z0tp', {
+        paymentId: 'tr_WDqYK6vllg'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -134,9 +134,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        chargebacks = await mollieClient.chargebacks.list();
-      })();
+      const chargebacks = mollieClient.chargebacks.iterate();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/chargebacks-api/list-payment-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-payment-chargebacks.rst
@@ -124,9 +124,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        let chargebacks = await mollieClient.payments_chargebacks.list({ paymentId: 'tr_WDqYK6vllg' });
-      })();
+      const chargebacks = mollieClient.paymentChargebacks.iterate({ paymentId: 'tr_WDqYK6vllg' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/create-customer-payment.rst
+++ b/source/reference/v2/customers-api/create-customer-payment.rst
@@ -151,19 +151,17 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const payment = await mollieClient.customers_payments.create({
-          customerId: 'cst_8wmqcHMN4U',
-          amount: {
-            currency: 'EUR',
-            value: '10.00', // We enforce the correct number of decimals through strings
-          },
-          description: 'Order #12345',
-          sequenceType: 'first',
-          redirectUrl: 'https://webshop.example.org/order/12345/',
-          webhookUrl: 'https://webshop.example.org/payments/webhook/',
-        });
-      })();
+      const payment = await mollieClient.customerPayments.create({
+        customerId: 'cst_8wmqcHMN4U',
+        amount: {
+          currency: 'EUR',
+          value: '10.00'
+        },
+        description: 'Order #12345',
+        sequenceType: 'first',
+        redirectUrl: 'https://webshop.example.org/order/12345/',
+        webhookUrl: 'https://webshop.example.org/payments/webhook/'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/create-customer.rst
+++ b/source/reference/v2/customers-api/create-customer.rst
@@ -121,12 +121,10 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const customer = await mollieClient.customers.create({
-          name: 'Customer A',
-          email: 'customer@example.org',
-        });
-      })();
+      const customer = await mollieClient.customers.create({
+        name: 'Customer A',
+        email: 'customer@example.org'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/delete-customer.rst
+++ b/source/reference/v2/customers-api/delete-customer.rst
@@ -78,9 +78,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const status = mollieClient.customers.delete('cst_8wmqcHMN4U');
-      })();
+      await mollieClient.customers.delete('cst_8wmqcHMN4U');
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/get-customer.rst
+++ b/source/reference/v2/customers-api/get-customer.rst
@@ -164,9 +164,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const customer = await mollieClient.customers.get('cst_kEn1PlbGa');
-      })();
+      const customer = await mollieClient.customers.get('cst_kEn1PlbGa');
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/list-customer-payments.rst
+++ b/source/reference/v2/customers-api/list-customer-payments.rst
@@ -95,9 +95,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const customerPayments = await mollieClient.customers_payments.list({ customerId: 'cst_8wmqcHMN4U' });
-      })();
+      const payments = mollieClient.customerPayments.iterate({ customerId: 'cst_8wmqcHMN4U' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/list-customers.rst
+++ b/source/reference/v2/customers-api/list-customers.rst
@@ -143,13 +143,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        // First page
-        let customers = await mollieClient.customers.page();
-
-        // Next page
-        customers = await customers.nextPage();
-      })();
+      const customers = mollieClient.customers.iterate();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/update-customer.rst
+++ b/source/reference/v2/customers-api/update-customer.rst
@@ -123,12 +123,10 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const customer = await mollieClient.customers.update('cst_8wmqcHMN4U' , {
-          name: 'Updated Customer A',
-          email: 'updated-customer@example.org'
-        });
-      })();
+      const customer = await mollieClient.customers.update('cst_8wmqcHMN4U', {
+        name: 'Updated Customer A',
+        email: 'updated-customer@example.org'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -168,17 +168,15 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const mandate = await mollieClient.customers_mandates.create({
-          customerId: 'cst_4qqhO89gsT',
-          method: 'directdebit',
-          consumerName: 'John Doe',
-          consumerAccount: 'NL55INGB0000000000',
-          consumerBic: 'INGBNL2A',
-          signatureDate: '2018-05-07',
-          mandateReference: 'YOUR-COMPANY-MD13804',
-        });
-      })();
+      const mandate = await mollieClient.customerMandates.create({
+        customerId: 'cst_4qqhO89gsT',
+        method: 'directdebit',
+        consumerName: 'John Doe',
+        consumerAccount: 'NL55INGB0000000000',
+        consumerBic: 'INGBNL2A',
+        signatureDate: '2018-05-07',
+        mandateReference: 'YOUR-COMPANY-MD13804'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/mandates-api/get-mandate.rst
+++ b/source/reference/v2/mandates-api/get-mandate.rst
@@ -219,12 +219,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const mandate = await mollieClient.customers_mandates.get(
-          'mdt_h3gAaD5zP',
-          { customerId: 'cst_4qqhO89gsT' }
-        );
-      })();
+      const mandate = await mollieClient.customerMandates.get('mdt_h3gAaD5zP', {
+        customerId: 'cst_4qqhO89gsT'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/mandates-api/list-mandates.rst
+++ b/source/reference/v2/mandates-api/list-mandates.rst
@@ -137,9 +137,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const mandates = await mollieClient.customers_mandates.page({ customerId: 'cst_stTC2WHAuS' });
-      })();
+      const mandates = mollieClient.customerMandates.iterate({ customerId: 'cst_stTC2WHAuS' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/mandates-api/revoke-mandate.rst
+++ b/source/reference/v2/mandates-api/revoke-mandate.rst
@@ -72,12 +72,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const status = await mollieClient.customers_mandates.delete(
-          'mdt_pWUnw6pkBN',
-          { customerId: 'cst_stTC2WHAuS' }
-        );
-      })();
+      await mollieClient.customerMandates.revoke('mdt_pWUnw6pkBN', {
+        customerId: 'cst_stTC2WHAuS'
+      });
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/methods-api/get-method.rst
+++ b/source/reference/v2/methods-api/get-method.rst
@@ -265,9 +265,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const method = await mollieClient.methods.get('ideal', { include: ['issuers', 'pricing'] });
-      })();
+      const method = await mollieClient.methods.get('ideal', { include: ['issuers', 'pricing'] });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/methods-api/list-methods.rst
+++ b/source/reference/v2/methods-api/list-methods.rst
@@ -242,13 +242,11 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        // Methods for the Payments API
-        let methods = await mollieClient.methods.all();
+      // Methods for the Payments API.
+      let methods = await mollieClient.methods.list();
 
-        // Methods for the Orders API
-        methods = await mollieClient.methods.all({ resource: 'orders' });
-      })();
+      // Methods for the Orders API.
+      methods = await mollieClient.methods.list({ resource: 'orders' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -94,9 +94,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const canceledOrder = await mollieClient.orders.cancel('ord_8wmqcHMN4U');
-      })();
+      const canceledOrder = await mollieClient.orders.cancel('ord_8wmqcHMN4U');
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -957,98 +957,95 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const order = await mollieClient.orders.create({
-          amount: {
-            value: '1027.99',
-            currency: 'EUR',
-          },
-          billingAddress: {
-            organizationName: 'Mollie B.V.',
-            streetAndNumber: 'Keizersgracht 126',
-            city: 'Amsterdam',
-            region: 'Noord-Holland',
-            postalCode: '1234AB',
-            country: 'NL',
-            title: 'Dhr.',
-            givenName: 'Piet',
-            familyName: 'Mondriaan',
-            email: 'piet@mondriaan.com',
-            phone: '+31309202070',
-          },
-          shippingAddress: {
-            organizationName: 'Mollie B.V.',
-            streetAndNumber: 'Prinsengracht 126',
-            streetAdditional: '4th floor',
-            city: 'Haarlem',
-            region: 'Noord-Holland',
-            postalCode: '5678AB',
-            country: 'NL',
-            title: 'Mr.',
-            givenName: 'Chuck',
-            familyName: 'Norris',
-            email: 'norris@chucknorrisfacts.net',
-          },
-          metadata: {
-            order_id: '1337',
-            description: 'Lego cars',
-          },
-          consumerDateOfBirth: '1958-01-31',
-          locale: 'nl_NL',
-          orderNumber: '1337',
-          redirectUrl: 'https://example.org/redirect',
-          webhookUrl: 'https://example.org/webhook',
-          method: 'klarnapaylater',
-          lines: [
-            {
-              type: 'physical',
-              sku: '5702016116977',
-              name: 'LEGO 42083 Bugatti Chiron',
-              productUrl: 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
-              imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
-              quantity: 2,
-              vatRate: '21.00',
-              unitPrice: {
-                currency: 'EUR',
-                value: '399.00',
-              },
-              totalAmount: {
-                currency: 'EUR',
-                value: '698.00',
-              },
-              discountAmount: {
-                currency: 'EUR',
-                value: '100.00',
-              },
-              vatAmount: {
-                currency: 'EUR',
-                value: '121.14',
-              },
+      const order = await mollieClient.orders.create({
+        amount: {
+          value: '1027.99',
+          currency: 'EUR'
+        },
+        billingAddress: {
+          organizationName: 'Mollie B.V.',
+          streetAndNumber: 'Keizersgracht 126',
+          city: 'Amsterdam',
+          region: 'Noord-Holland',
+          postalCode: '1234AB',
+          country: 'NL',
+          title: 'Dhr.',
+          givenName: 'Piet',
+          familyName: 'Mondriaan',
+          email: 'piet@mondriaan.com',
+          phone: '+31309202070'
+        },
+        shippingAddress: {
+          organizationName: 'Mollie B.V.',
+          streetAndNumber: 'Prinsengracht 126',
+          streetAdditional: '4th floor',
+          city: 'Haarlem',
+          region: 'Noord-Holland',
+          postalCode: '5678AB',
+          country: 'NL',
+          title: 'Mr.',
+          givenName: 'Chuck',
+          familyName: 'Norris',
+          email: 'norris@chucknorrisfacts.net'
+        },
+        metadata: {
+          order_id: '1337',
+          description: 'Lego cars'
+        },
+        locale: 'nl_NL',
+        orderNumber: '1337',
+        redirectUrl: 'https://example.org/redirect',
+        webhookUrl: 'https://example.org/webhook',
+        method: 'klarnapaylater',
+        lines: [
+          {
+            type: 'physical',
+            sku: '5702016116977',
+            name: 'LEGO 42083 Bugatti Chiron',
+            productUrl: 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
+            imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
+            quantity: 2,
+            vatRate: '21.00',
+            unitPrice: {
+              currency: 'EUR',
+              value: '399.00'
             },
-            {
-              type: 'physical',
-              sku: '5702015594028',
-              name: 'LEGO 42056 Porsche 911 GT3 RS',
-              productUrl: 'https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056',
-              imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$',
-              quantity: 1,
-              vatRate: '21.00',
-              unitPrice: {
-                currency: 'EUR',
-                value: '329.99',
-              },
-              totalAmount: {
-                currency: 'EUR',
-                value: '329.99',
-              },
-              vatAmount: {
-                currency: 'EUR',
-                value: '57.27',
-              },
+            totalAmount: {
+              currency: 'EUR',
+              value: '698.00'
             },
-          ],
-        });
-      })();
+            discountAmount: {
+              currency: 'EUR',
+              value: '100.00'
+            },
+            vatAmount: {
+              currency: 'EUR',
+              value: '121.14'
+            }
+          },
+          {
+            type: 'physical',
+            sku: '5702015594028',
+            name: 'LEGO 42056 Porsche 911 GT3 RS',
+            productUrl: 'https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056',
+            imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$',
+            quantity: 1,
+            vatRate: '21.00',
+            unitPrice: {
+              currency: 'EUR',
+              value: '329.99'
+            },
+            totalAmount: {
+              currency: 'EUR',
+              value: '329.99'
+            },
+            vatAmount: {
+              currency: 'EUR',
+              value: '57.27'
+            }
+          }
+        ]
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -542,9 +542,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const order = await mollieClient.orders.get('ord_stTC2WHAuS');
-      })();
+      const order = await mollieClient.orders.get('ord_stTC2WHAuS');
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/list-orders.rst
+++ b/source/reference/v2/orders-api/list-orders.rst
@@ -146,10 +146,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const mostRecentOrders = await mollieClient.orders.page();
-        const previousOrders = await mostRecentOrders.nextPage();
-      })();
+      const orders = mollieClient.orders.iterate();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/update-order-line.rst
+++ b/source/reference/v2/orders-api/update-order-line.rst
@@ -221,14 +221,12 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const order = await mollieClient.orders_lines.update('odl_dgtxyl', {
-          orderId: 'ord_pbjz8x',
-          name: 'LEGO 71043 Hogwarts™ Castle',
-          productUrl: 'https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043',
-          imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$',
-        });
-      })();
+      const order = await mollieClient.orderLines.update('odl_dgtxyl', {
+        orderId: 'ord_pbjz8x',
+        name: 'LEGO 71043 Hogwarts™ Castle',
+        productUrl: 'https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043',
+        imageUrl: 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -320,23 +320,21 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const order = await mollieClient.orders.update('ord_kEn1PlbGa', {
-           billingAddress: {
-             organizationName: 'Mollie B.V.',
-             streetAndNumber: 'Keizersgracht 126',
-             city: 'Amsterdam',
-             region: 'Noord-Holland',
-             postalCode: '1234AB',
-             country: 'NL',
-             title: 'Dhr',
-             givenName: 'Piet',
-             familyName: 'Mondriaan',
-             email: 'piet@mondriaan.com',
-             phone: '+31208202070',
-          },
-        });
-      })();
+      const order = await mollieClient.orders.update('ord_kEn1PlbGa', {
+         billingAddress: {
+           organizationName: 'Mollie B.V.',
+           streetAndNumber: 'Keizersgracht 126',
+           city: 'Amsterdam',
+           region: 'Noord-Holland',
+           postalCode: '1234AB',
+           country: 'NL',
+           title: 'Dhr',
+           givenName: 'Piet',
+           familyName: 'Mondriaan',
+           email: 'piet@mondriaan.com',
+           phone: '+31208202070'
+        }
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/cancel-payment.rst
+++ b/source/reference/v2/payments-api/cancel-payment.rst
@@ -84,9 +84,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const canceledPayment = await mollieClient.payments.delete('tr_Eq8xzWUPA4');
-      })();
+      const canceledPayment = await mollieClient.payments.cancel('tr_Eq8xzWUPA4');
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -813,20 +813,18 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const payment = await mollieClient.payments.create({
-          amount: {
-            currency: 'EUR',
-            value: '10.00', // We enforce the correct number of decimals through strings
-          },
-          description: 'Order #12345',
-          redirectUrl: 'https://webshop.example.org/order/12345/',
-          webhookUrl: 'https://webshop.example.org/payments/webhook/',
-          metadata: {
-            order_id: '12345',
-          },
-        });
-      })();
+      const payment = await mollieClient.payments.create({
+        amount: {
+          currency: 'EUR',
+          value: '10.00'
+        },
+        description: 'Order #12345',
+        redirectUrl: 'https://webshop.example.org/order/12345/',
+        webhookUrl: 'https://webshop.example.org/payments/webhook/',
+        metadata: {
+          order_id: '12345'
+        }
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -1164,9 +1164,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const payment = await mollieClient.payments.get('tr_Eq8xzWUPA4');
-      })();
+      const payment = await mollieClient.payments.get('tr_Eq8xzWUPA4');
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/payments-api/list-payments.rst
+++ b/source/reference/v2/payments-api/list-payments.rst
@@ -176,9 +176,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const payments = await mollieClient.payments.list();
-      })();
+      const payments = mollieClient.payments.iterate();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/cancel-payment-refund.rst
+++ b/source/reference/v2/refunds-api/cancel-payment-refund.rst
@@ -76,9 +76,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const status = await mollieClient.payments_refunds.cancel('re_4qqhO89gsT', { paymentId: 'tr_WDqYK6vllg' });
-      })();
+      await mollieClient.paymentRefunds.cancel('re_4qqhO89gsT', {
+        paymentId: 'tr_WDqYK6vllg'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/create-order-refund.rst
+++ b/source/reference/v2/refunds-api/create-order-refund.rst
@@ -193,16 +193,14 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const refund = await mollieClient.orders_refunds.create({
-          orderId: 'ord_stTC2WHAuS',
-          lines: {
-            id: 'odl_dgtxyl',
-            quantity: 1,
-          },
-          description: 'Required quantity not in stock, refunding one photo book.',
-        });
-      })();
+      const refund = await mollieClient.orderRefunds.create({
+        orderId: 'ord_stTC2WHAuS',
+        lines: [{
+          id: 'odl_dgtxyl',
+          quantity: 1
+        }],
+        description: 'Required quantity not in stock, refunding one photo book.'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/create-payment-refund.rst
+++ b/source/reference/v2/refunds-api/create-payment-refund.rst
@@ -209,15 +209,13 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const refund = await mollieClient.payments_refunds.create({
-          paymentId: 'tr_WDqYK6vllg',
-          amount: {
-            value: '5.95',
-            currency: 'EUR',
-          },
-        });
-      })();
+      const refund = await mollieClient.paymentRefunds.create({
+        paymentId: 'tr_WDqYK6vllg',
+        amount: {
+          value: '5.95',
+          currency: 'EUR'
+        }
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/get-payment-refund.rst
+++ b/source/reference/v2/refunds-api/get-payment-refund.rst
@@ -261,9 +261,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const refund = await mollieClient.payments_refunds.get('re_4qqhO89gsT', { paymentId: 'tr_WDqYK6vllg' });
-      })();
+      const refund = await mollieClient.paymentRefunds.get('re_4qqhO89gsT', {
+        paymentId: 'tr_WDqYK6vllg'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/list-order-refunds.rst
+++ b/source/reference/v2/refunds-api/list-order-refunds.rst
@@ -143,9 +143,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const refunds = await mollieClient.orders_refunds.all({ orderId: 'ord_stTC2WHAuS' });
-      })();
+      const refunds = mollieClient.orderRefunds.iterate({ orderId: 'ord_stTC2WHAuS' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/list-payment-refunds.rst
+++ b/source/reference/v2/refunds-api/list-payment-refunds.rst
@@ -143,9 +143,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const refunds = await mollieClient.payments_refunds.page({ paymentId: 'tr_WDqYK6vllg' });
-      })();
+      const refunds = mollieClient.paymentRefunds.iterate({ paymentId: 'tr_WDqYK6vllg' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/refunds-api/list-refunds.rst
+++ b/source/reference/v2/refunds-api/list-refunds.rst
@@ -154,9 +154,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const refunds = await mollieClient.refunds.list();
-      })();
+      const refunds = mollieClient.refunds.iterate();
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/shipments-api/create-shipment.rst
+++ b/source/reference/v2/shipments-api/create-shipment.rst
@@ -239,39 +239,24 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        let shipment = await mollieClient.orders_shipments.create({
-          orderId: 'ord_kEn1PlbGa',
-          lines: [
-            {
-              id: 'odl_dgtxyl',
-              quantity: 1,  // you can set the quantity if not all is shipped at once
-            },
-            {
-              id: 'odl_jp31jz',  // all is shipped if no quantity is set
-            },
-          ],
-          tracking: {
-            carrier: 'PostNL',
-            code: '3SKABA000000000',
-            url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C',
+      const shipment = await mollieClient.orderShipments.create({
+        orderId: 'ord_kEn1PlbGa',
+        lines: [
+          {
+            id: 'odl_dgtxyl',
+            quantity: 1
           },
-        });
-
-        // If all lines are shipped, there is no need to specify them:
-        shipment = await mollieClient.orders_shipments.create({
-          orderId: 'ord_kEn1PlbGa',
-          lines: [],
-          tracking: {
-            carrier: 'PostNL',
-            code: '3SKABA000000000',
-            url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C',
-          },
-        });
-
-        // Or when no tracking is specified:
-        shipment = await mollieClient.orders_shipments.create({ orderId: 'ord_kEn1PlbGa', lines: [] });
-      })();
+          {
+            id: 'odl_jp31jz'
+            // If no quantity is specified, the shipment ships the complete order line
+          }
+        ],
+        tracking: {
+          carrier: 'PostNL',
+          code: '3SKABA000000000',
+          url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C'
+        }
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/shipments-api/get-shipment.rst
+++ b/source/reference/v2/shipments-api/get-shipment.rst
@@ -153,11 +153,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const shipment = await mollieClient.orders_shipments.get('shp_3wmsgCJN4U', {
-          orderId: 'ord_kEn1PlbGa',
-        });
-      })();
+      const shipment = await mollieClient.orderShipments.get('shp_3wmsgCJN4U', {
+        orderId: 'ord_kEn1PlbGa'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/shipments-api/list-shipments.rst
+++ b/source/reference/v2/shipments-api/list-shipments.rst
@@ -109,9 +109,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const shipments = await mollieClient.orders_shipments.all({ orderId: 'ord_kEn1PlbGa' });
-      })();
+      const shipments = await mollieClient.orderShipments.list({ orderId: 'ord_kEn1PlbGa' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/shipments-api/update-shipment.rst
+++ b/source/reference/v2/shipments-api/update-shipment.rst
@@ -137,15 +137,14 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const shipment = await mollieClient.orders_shipments.update('shp_3wmsgCJN4U', {
-          tracking: {
-            carrier: 'PostNL',
-            code: '3SKABA000000000',
-            url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C',
-          },
-        });
-      })();
+      const shipment = await mollieClient.orderShipments.update('shp_3wmsgCJN4U', {
+        orderId: 'ord_kEn1PlbGa',
+        tracking: {
+          carrier: 'PostNL',
+          code: '3SKABA000000000',
+          url: 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C'
+        }
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/subscriptions-api/cancel-subscription.rst
+++ b/source/reference/v2/subscriptions-api/cancel-subscription.rst
@@ -87,9 +87,9 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const subscription = await mollieClient.customers_subscriptions.cancel('sub_rVKGtNd6s3', { customerId: 'cst_stTC2WHAuS' });
-      })();
+      const canceledSubscription = await mollieClient.customerSubscriptions.cancel('sub_rVKGtNd6s3', {
+        customerId: 'cst_stTC2WHAuS'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/subscriptions-api/create-subscription.rst
+++ b/source/reference/v2/subscriptions-api/create-subscription.rst
@@ -230,19 +230,17 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const subscription = await mollieClient.customers_subscriptions.create({
-          customerId: 'cst_stTC2WHAuS',
-          amount: {
-            currency: 'EUR',
-            value: '25.00',
-          },
-          times: 4,
-          interval: '3 months',
-          description: 'Quarterly payment',
-          webhookUrl: 'https://webshop.example.org/subscriptions/webhook/',
-        });
-      })();
+      const subscription = await mollieClient.customerSubscriptions.create({
+        customerId: 'cst_stTC2WHAuS',
+        amount: {
+          currency: 'EUR',
+          value: '25.00'
+        },
+        times: 4,
+        interval: '3 months',
+        description: 'Quarterly payment',
+        webhookUrl: 'https://webshop.example.org/subscriptions/webhook/'
+      });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/subscriptions-api/get-subscription.rst
+++ b/source/reference/v2/subscriptions-api/get-subscription.rst
@@ -247,9 +247,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const subscription = await mollieClient.customers_subscriptions.get('sub_rVKGtNd6s3', { customerId: 'cst_stTC2WHAuS' });
-      })();
+      const subscriptions = mollieClient.customerSubscriptions.iterate({ customerId: 'cst_8wmqcHMN4U' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/subscriptions-api/list-subscriptions.rst
+++ b/source/reference/v2/subscriptions-api/list-subscriptions.rst
@@ -149,9 +149,7 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const subscriptions = await mollieClient.customers_subscriptions.all({ customerId: 'cst_8wmqcHMN4U' });
-      })();
+      const subscriptions = await mollieClient.customerSubscriptions.all({ customerId: 'cst_8wmqcHMN4U' });
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/subscriptions-api/update-subscription.rst
+++ b/source/reference/v2/subscriptions-api/update-subscription.rst
@@ -198,19 +198,17 @@ Example
       const { createMollieClient } = require('@mollie/api-client');
       const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 
-      (async () => {
-        const subscription = await mollieClient.customers_subscriptions.update('sub_8EjeBVgtEn', {
-          customerId: 'cst_8wmqcHMN4U',
-          amount: {
-            currency: 'EUR',
-            value: '10.00',
-          },
-          times: 42,
-          startDate: '2018-12-12',
-          description: 'Mollie recurring subscription',
-          webhookUrl: 'https://example.org/webhook',
-        });
-      })();
+      const subscription = await mollieClient.customerSubscriptions.update('sub_8EjeBVgtEn', {
+        customerId: 'cst_8wmqcHMN4U',
+        amount: {
+          currency: 'EUR',
+          value: '10.00'
+        },
+        times: 42,
+        startDate: '2018-12-12',
+        description: 'Mollie recurring subscription',
+        webhookUrl: 'https://example.org/webhook'
+      });
 
 Response
 ^^^^^^^^


### PR DESCRIPTION
* Updated examples to use dromedary case (`customerPayments` instead of `customers_payments`). Dromedary case is preferred as it is standard in the JavaScript community, plus snake case will be removed in 4.0.0. 🐪
* Updated examples to use the iteration API instead of the pagination API. The iteration API is likely what most users will want to use.
* Removed the asynchronous IIFE: `(async () => { … })()`. Promises are well-established in the JavaScript community today. I don't suspect the top-level `await` keyword would confuse anyone. (In fact, at this point I think it's more likely that the asynchronous IIFE confuses users.)
* Fixed a mistake in the example on [the page about user agent strings](//docs.mollie.com/integration-partners/user-agent-strings).