### PR TITLE
Add info about webhook retries to the Create Payment Links page

### DIFF
--- a/source/overview/webhooks.rst
+++ b/source/overview/webhooks.rst
@@ -78,6 +78,11 @@ about webhooks for payments.
 The :ref:`Recurring Payments guide <payments/recurring/subscription-webhooks>` has some additional information about
 webhooks for subscriptions.
 
+Payment Links API
+^^^^^^^^^^^^^^^^^
+The webhook URL specified when :doc:`creating a payment link </reference/v2/payment-links-api/create-payment-link>` is
+called every time the underlying payment's status changes. See the `Payments API`_ section for more on the conditions payment webhooks are called on.
+
 Retry schema
 ------------
 In response to Mollie calling your webhook, you only have to return the HTTP status ``200 OK``. Mollie then knows your

--- a/source/reference/v2/payment-links-api/create-payment-link.rst
+++ b/source/reference/v2/payment-links-api/create-payment-link.rst
@@ -68,6 +68,8 @@ Parameters
    `ngrok <https://lornajane.net/posts/2015/test-incoming-webhooks-locally-with-ngrok>`_ to have the webhooks delivered
    to your local machine.
 
+   See :doc:`webhook </overview/webhooks>` documentation for more details.
+
 .. parameter:: expiresAt
    :type: datetime
    :condition: optional


### PR DESCRIPTION
Adding some info about webhook retries to the page about [Creating Payment Links](https://docs.mollie.com/reference/v2/payment-links-api/create-payment-link) (the green "Note" block)

![Screen Shot 2022-04-08 at 16 39 19](https://user-images.githubusercontent.com/1506254/162762959-143af7f3-ae1b-4abf-86ac-35a789b654f7.png)
