### PR TITLE
Pin the jinja2 package version we install, as 'make html' is currently broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==1.8.5
+jinja2==3.0.0
 docutils==0.17.1
 sphinx-autobuild==0.7.1
 cloud-sptheme==1.10.0


### PR DESCRIPTION
Please see https://github.com/readthedocs/readthedocs.org/issues/9037 for an explanation. It would probably be better to upgrade the ancient sphinx version we use, but I did not want to go down that rabbit hole.