### PR TITLE
Document the in3 payment method

### DIFF
--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -3,6 +3,12 @@ Changelog
 Occasionally, we will add new resources, new fields, or new possible values to existing fields to the v2 Mollie API. All
 changes are documented here.
 
+June 2022
+=========
+????, ??
+--------
+- Added ``in3`` as new payment method, which is only supported by the Orders API. If you are interested in accepting in3 payments, you can enable the payment method via the Mollie Dashboard.
+
 March 2022
 =============
 Tuesday, 1st

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -5,8 +5,8 @@ changes are documented here.
 
 June 2022
 =========
-????, ??
---------
+Monday, 20th
+------------
 - Added ``in3`` as new payment method, which is only supported by the Orders API. If you are interested in accepting in3 payments, you can enable the payment method via the Mollie Dashboard.
 
 March 2022

--- a/source/index.rst
+++ b/source/index.rst
@@ -46,6 +46,7 @@ Mollie is always adding new payment methods. The Mollie API currently supports t
   YourGift etc.)
 * `Giropay <https://www.mollie.com/en/payments/giropay>`_
 * `iDEAL <https://www.mollie.com/en/payments/ideal>`_
+* `in3 <https://www.mollie.com/en/payments/in3>`_
 * `KBC/CBC Payment Button <https://www.mollie.com/en/payments/kbc-cbc>`_
 * `Klarna Pay now <https://www.mollie.com/en/payments/klarna-pay-now>`_
 * `Klarna Pay later <https://www.mollie.com/en/payments/klarna-pay-later>`_

--- a/source/orders/migrate-to-orders.rst
+++ b/source/orders/migrate-to-orders.rst
@@ -51,7 +51,7 @@ The ``billingAddress`` should contain the address of the person who will be bill
 | ``locale``             | Recommended in Payments API.               | Required for Orders API.                       |
 +------------------------+--------------------------------------------+------------------------------------------------+
 | ``method``             | Does not support payment methods that      | Supports *Klarna Pay now*, *Klarna Pay later*, |
-|                        | require order details.                     | *Klarna Slice it* and voucher payments.        |
+|                        | require order details.                     | *Klarna Slice it*, *in3* and voucher payments. |
 +------------------------+--------------------------------------------+------------------------------------------------+
 | ``metadata``           | *Identical between Payments API and Orders API.*                                            |
 +------------------------+--------------------------------------------+------------------------------------------------+
@@ -83,7 +83,7 @@ When the order is created the response will contain a ``checkout`` URL just like
 Your customer should be redirected to this URL to complete the order payment. This is the same as in the Payments API.
 
 The only difference occurs when the customer chooses a payment method that requires authorization. This is the case with
-*pay after delivery* payment methods. The customer will have to authorize the payment, and the payment is not executed
+Klarna payment methods. The customer will have to authorize the payment, and the payment is not executed
 immediately. When a shipment is created for an authorized order a *capture* is made to process the payment. For more
 info on the authorize payment flow please see :doc:`Order status changes </orders/status-changes>` for details on the
 orders' statuses.

--- a/source/orders/overview.rst
+++ b/source/orders/overview.rst
@@ -8,7 +8,7 @@ amount of time (default 28 days).
 
 Just as a regular payment, the order will have a ``_links.checkout`` property where you can redirect your customer to
 pay for the order. For each attempt to pay, a payment object is created. If the customer pays for the order, the order
-will transition to the ``paid`` state (or ``authorized`` in case of pay after delivery).
+will transition to the ``paid`` state (or ``authorized`` in case of Klarna payment methods).
 
 Should the initial payment fail, the order remains in the ``created`` state so that your customer can try to pay again.
 This can be done using a dedicated link available through the Dashboard which you can share with your customer, or you
@@ -20,7 +20,7 @@ This is mandatory for pay-after-delivery methods. Only shipped amounts will be s
 The following payment methods require the Orders API and cannot be used with the
 :doc:`Payments API </payments/accepting-payments>`:
 
-* *Pay after delivery* payment methods, such as Klarna Pay later and Klarna Slice it
+* *Pay after delivery* payment methods, such as Klarna Pay later, Klarna Slice it and in3
 * Klarna Pay now
 * Eco vouchers, gift vouchers, and meal vouchers
 

--- a/source/orders/why-use-orders.rst
+++ b/source/orders/why-use-orders.rst
@@ -11,7 +11,7 @@ Which extra features can I use with the Orders API?
 ---------------------------------------------------
 * The Orders API allows you to use Mollie for your order management, including the payment process.
 
-* **Pay after delivery** payment methods such as **Klarna Pay later** or **Klarna Slice it**, **Klarna Pay now**, as
+* **Pay after delivery** payment methods such as **Klarna Pay later**, **Klarna Slice it** or **in3**, **Klarna Pay now**, as
   well as **eco vouchers, gift vouchers, and meal vouchers** require the Orders API and cannot be used with the Payments
   API. This is because the order information is needed to do a risk assessment or to calculate which products are
   eligible per voucher.

--- a/source/payments/build-your-own-checkout.rst
+++ b/source/payments/build-your-own-checkout.rst
@@ -52,7 +52,7 @@ The next steps for a deeper integration depend on which payment methods you are 
 an overview of the typical flow for each of our payment methods, and how they can be integrated further.
 
 .. list-table::
-   :widths: 15, 50, 35
+   :widths: 25, 45, 30
    :header-rows: 1
 
    * - Method
@@ -113,6 +113,12 @@ an overview of the typical flow for each of our payment methods, and how they ca
        integrated using the QR embed in the Payments API. See the :doc:`QR codes guide </payments/qr-codes>` for
        details.
 
+   * - **in3**
+     - #. Customer selects in3 at checkout.
+       #. Customer gets redirected to in3 to pay the first instalment.
+       #. Customer returns to the webshop.
+     - No deeper integration possible.
+
    * - **KBC/CBC**
      - #. Customer selects KBC/CBC at checkout.
        #. Customer gets redirected to Mollie to select their bank.
@@ -121,17 +127,12 @@ an overview of the typical flow for each of our payment methods, and how they ca
      - The issuer selection screen (step 2) can be integrated using the Methods API. See
        :ref:`embedding-issuer-selection` below.
 
-   * - **Klarna: Pay later**
-     - #. Customer selects Pay later at checkout.
+   * - | **Klarna: Pay now**
+       | **Klarna: Pay later**
+       | **Klarna: Slice it**
+     - #. Customer selects a Klarna payment method at checkout.
        #. Customer gets redirected to Klarna to verify their payment with their Klarna account, or by supplying
           additional information.
-       #. Customer returns to the webshop.
-     - No deeper integration possible.
-
-   * - **Klarna: Slice it**
-     - #. Customer selects Slice it at checkout.
-       #. Customer gets redirected to Klarna to verify their payment instalment plan with their Klarna account, or by
-          supplying additional information.
        #. Customer returns to the webshop.
      - No deeper integration possible.
 

--- a/source/payments/status-changes.rst
+++ b/source/payments/status-changes.rst
@@ -85,7 +85,8 @@ Expiry times per payment method
 | - MyBank                      |                                   |
 | - Przelewy24                  |                                   |
 +-------------------------------+-----------------------------------+
-| - SOFORT Banking              | 2 hours                           |
+| - in3                         | 2 hours                           |
+| - SOFORT Banking              |                                   |
 +-------------------------------+-----------------------------------+
 | - PayPal                      | 3 hours                           |
 | - Vouchers                    |                                   |

--- a/source/reference/v1/payments-api/create-payment.rst
+++ b/source/reference/v1/payments-api/create-payment.rst
@@ -98,8 +98,8 @@ Parameters
    Possible values: ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps`` ``giftcard`` ``giropay``
    ``ideal`` ``kbc`` ``mistercash`` ``mybank`` ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort``
 
-   .. note:: If you are looking to create payments with the Klarna Pay now, Klarna Pay later, Klarna Slice it or Voucher
-             payment methods, please use the :doc:`Orders API </reference/v2/orders-api/overview>` instead.
+   .. note:: If you are looking to create payments with the Klarna Pay now, Klarna Pay later, Klarna Slice it, in3 or
+             Voucher payment methods, please use the :doc:`Orders API </reference/v2/orders-api/overview>` instead.
 
 .. parameter:: metadata
    :type: mixed

--- a/source/reference/v1/settlements-api/list-settlement-payments.rst
+++ b/source/reference/v1/settlements-api/list-settlement-payments.rst
@@ -21,9 +21,9 @@ List settlement payments
 
 Retrieve all payments included in a settlement.
 
-Note that payments for *pay after delivery* methods (such as Klarna Pay later) are not listed in here. These payment
-methods are settled using captures. To retrieve the captures, the v2 api needs to be used, see the
-:doc:`List settlement captures endpoint </reference/v2/settlements-api/list-settlement-captures>`.
+Note that payments for Klarna payment methods are not listed in here. These payment methods are settled using captures.
+To retrieve the captures, the v2 api needs to be used, see the :doc:`List settlement captures endpoint
+</reference/v2/settlements-api/list-settlement-captures>`.
 
 Parameters
 ----------

--- a/source/reference/v2/orders-api/cancel-order-lines.rst
+++ b/source/reference/v2/orders-api/cancel-order-lines.rst
@@ -12,9 +12,9 @@ Cancel order lines
    :organization_access_tokens: true
    :oauth: true
 
-This endpoint can be used to cancel one or more order lines that were previously authorized using a *pay after delivery*
-payment method. Use the :doc:`Cancel order endpoint </reference/v2/orders-api/cancel-order>` if you want to cancel the
-entire order or the remainder of the order.
+This endpoint can be used to cancel one or more order lines that were previously authorized using a Klarna payment
+method. Use the :doc:`Cancel order endpoint </reference/v2/orders-api/cancel-order>` if you want to cancel the entire
+order or the remainder of the order.
 
 Canceling or partially canceling an order line will immediately release the authorization held for that amount. Your
 customer will be able to see the updated order in his portal / app. Any canceled lines will be removed from the

--- a/source/reference/v2/orders-api/create-order-payment.rst
+++ b/source/reference/v2/orders-api/create-order-payment.rst
@@ -38,8 +38,8 @@ Replace ``orderId`` in the endpoint URL by the order's ID, for example ``ord_8wm
    methods from a specific country to your customer ``["bancontact", "belfius"]``.
 
    Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
-   ``giftcard`` ``giropay`` ``ideal`` ``kbc``  ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``paypal`` ``paysafecard``
-   ``przelewy24`` ``sofort``
+   ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc``  ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``paypal``
+   ``paysafecard`` ``przelewy24`` ``sofort``
 
 .. parameter:: customerId
    :type: string

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -12,8 +12,9 @@ Create order
    :organization_access_tokens: true
    :oauth: true
 
-Using the :doc:`Orders API </orders/overview>` is the preferred approach when integrating the Mollie
-API into e-commerce applications such as webshops. If you want to use *Klarna Pay now*, *Klarna Pay later*, *Klarna Slice it* or *Vouchers*, using the Orders API is mandatory.
+Using the :doc:`Orders API </orders/overview>` is the preferred approach when integrating the Mollie API into e-commerce
+applications such as webshops. If you want to use *Klarna Pay now*, *Klarna Pay later*, *Klarna Slice it*, *in3* or
+*Vouchers*, using the Orders API is mandatory.
 
 Creating an Order will automatically create the required Payment to allow your customer to pay for the order.
 

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -425,8 +425,8 @@ Parameters
    methods from a specific country to your customer ``['bancontact', 'belfius']``.
 
    Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
-   ``giftcard`` ``giropay`` ``ideal`` ``kbc``  ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``mybank`` ``paypal``
-   ``paysafecard`` ``przelewy24`` ``sofort`` ``voucher``
+   ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc``  ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``mybank``
+   ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort`` ``voucher``
 
 .. parameter:: payment
    :type: object

--- a/source/reference/v2/orders-api/update-order-line.rst
+++ b/source/reference/v2/orders-api/update-order-line.rst
@@ -25,9 +25,9 @@ want to substitute a product for an entirely different one.
 Alternatively, you can also (partially) :doc:`cancel order lines </reference/v2/orders-api/cancel-order-lines>` instead
 of updating the quantity.
 
-When updating an order line that uses a *pay after delivery* method such as *Klarna Pay later*,
-Klarna may decline the requested changes, resulting in an error response from the Mollie API.
-The order remains intact, though the requested changes are not persisted.
+When updating an order line for an order that uses a Klarna payment method, Klarna may decline the requested changes,
+resulting in an error response from the Mollie API. The order remains intact, though the requested changes are not
+persisted.
 
 Parameters
 ----------

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -14,9 +14,8 @@ Update order
 
 This endpoint can be used to update the billing and/or shipping address of an order.
 
-When updating an order that uses a *pay after delivery* method such as *Klarna Pay later*,
-Klarna may decline the requested changes, resulting in an error response from the Mollie API.
-The order remains intact, though the requested changes are not persisted.
+When updating an order that uses a Klarna payment method, Klarna may decline the requested changes, resulting in an
+error response from the Mollie API. The order remains intact, though the requested changes are not persisted.
 
 Parameters
 ----------

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -120,7 +120,7 @@ Parameters
    Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
    ``giftcard`` ``giropay`` ``ideal`` ``kbc`` ``mybank``  ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort``
 
-   .. note:: If you are looking to create payments with the Klarna Pay now, Klarna Pay later, Klarna Slice it, or
+   .. note:: If you are looking to create payments with the Klarna Pay now, Klarna Pay later, Klarna Slice it, in3 or
       voucher payment methods, please use :doc:`/reference/v2/orders-api/create-order` instead.
 
 .. parameter:: restrictPaymentMethodsToCountry

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -271,7 +271,7 @@ Response
    If the payment is only partially paid with a gift card, the method remains ``giftcard``.
 
    Possible values: ``null`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
-   ``giftcard`` ``giropay`` ``ideal`` ``kbc`` ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``mybank``
+   ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc`` ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``mybank``
    ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort``
 
 .. parameter:: restrictPaymentMethodsToCountry

--- a/source/reference/v2/settlements-api/list-settlement-payments.rst
+++ b/source/reference/v2/settlements-api/list-settlement-payments.rst
@@ -14,8 +14,8 @@ List settlement payments
 
 Retrieve all Payments included in a Settlement.
 
-Note that payments for *pay after delivery* methods (such as Klarna Pay later) are not listed in here. These payment
-methods are settled using captures. To retrieve the captures, use the :doc:`list-settlement-captures`.
+Note that payments for Klarna payment methods are not listed in here. These payment methods are settled using captures.
+To retrieve the captures, use the :doc:`List settlement captures endpoint </reference/v2/settlements-api/list-settlement-captures>`.
 
 Parameters
 ----------


### PR DESCRIPTION
- List in3 on the documentation overview page.
- List in3 and Klarna Pay now on the 'Build your own checkout' page.
- List the expiry time of in3 payments.
- List in3 as a supported payment method for the Orders API.
- List in3 as a supported payment method for retrieving a payment.
- Add an entry in the v2 API changelog.

To do/to be confirmed:
- [x] Is the URL that I used on the overview page correct?
- [x] Update the changelog to feature the correct date once we are ready to ship this.