### PR TITLE
Add hint to use different profiles for different Apple Pay domains

### DIFF
--- a/source/wallets/applepay-direct-integration.rst
+++ b/source/wallets/applepay-direct-integration.rst
@@ -32,7 +32,7 @@ presence and validity of this file will be validated by Apple.
 Download the `domain validation file <http://www.mollie.com/.well-known/apple-developer-merchantid-domain-association>`_
 and place it on your server at ``https://[domain]/.well-known/apple-developer-merchantid-domain-association``.
 
-.. note:: It is advised to use one Mollie profile per domain, e.g. ``stage.merchant.example`` and 
+.. note:: You should use one Mollie profile per domain, e.g. ``stage.merchant.example`` and 
           ``www.merchant.example`` should have different profiles. Otherwise you might receive the error that Apple is
           unable to verify your domain.
 

--- a/source/wallets/applepay-direct-integration.rst
+++ b/source/wallets/applepay-direct-integration.rst
@@ -32,6 +32,10 @@ presence and validity of this file will be validated by Apple.
 Download the `domain validation file <http://www.mollie.com/.well-known/apple-developer-merchantid-domain-association>`_
 and place it on your server at ``https://[domain]/.well-known/apple-developer-merchantid-domain-association``.
 
+.. note:: It is advised to use one Mollie profile per domain, e.g. ``stage.merchant.example`` and 
+          ``www.merchant.example`` should have different profiles. Otherwise you might receive the error that Apple is
+          unable to verify your domain.
+
 Check if Apple Pay is available on the device
 ---------------------------------------------
 Check if Apple Pay is `available on the device


### PR DESCRIPTION
We should make it more clear in the documentation that Profiles and Domains are coupled together. Carelessly using the same profile for stage and live systems might result in payment failures.