### PR TITLE
Add the read-only "archived" property to payment links

### DIFF
--- a/source/reference/v2/payment-links-api/create-payment-link.rst
+++ b/source/reference/v2/payment-links-api/create-payment-link.rst
@@ -176,6 +176,7 @@ Response
            "value": "24.95",
            "currency": "EUR"
        },
+       "archived": false,
        "description": "Bicycle tires",
        "redirectUrl": "https://webshop.example.org/thanks",
        "webhookUrl": "https://webshop.example.org/payment-links/webhook/",

--- a/source/reference/v2/payment-links-api/get-payment-link.rst
+++ b/source/reference/v2/payment-links-api/get-payment-link.rst
@@ -67,6 +67,11 @@ Response
 
       A string containing the exact amount of the payment link in the given currency.
 
+.. parameter:: archived
+   :type: boolean
+
+   Whether the payment link is archived. Customers will not be able to complete payments on archived payment links.
+
 .. parameter:: redirectUrl
    :type: string
 
@@ -170,6 +175,7 @@ Response
            "value": "24.95",
            "currency": "EUR"
        },
+       "archived": false,
        "description": "Bicycle tires",
        "redirectUrl": "https://webshop.example.org/thanks",
        "webhookUrl": "https://webshop.example.org/payment-links/webhook/",

--- a/source/reference/v2/payment-links-api/list-payment-links.rst
+++ b/source/reference/v2/payment-links-api/list-payment-links.rst
@@ -151,6 +151,7 @@ Response
                          "value": "24.95",
                          "currency": "EUR"
                      },
+                     "archived": false,
                      "description": "Bicycle tires",
                      "redirectUrl": "https://webshop.example.org/thanks",
                      "webhookUrl": "https://webshop.example.org/payment-links/webhook/",


### PR DESCRIPTION
As-per the RFC, Payment Links' `archived` property is now exposed for reading.

Hopefully, my description makes sense.

![Screen Shot 2022-09-27 at 11 37 22](https://user-images.githubusercontent.com/1506254/192491583-87045137-1d73-40b0-8995-9990b937d3eb.png)
