### PR TITLE
Update get-payment-chargeback.rst

### DIFF
--- a/source/reference/v2/chargebacks-api/get-payment-chargeback.rst
+++ b/source/reference/v2/chargebacks-api/get-payment-chargeback.rst
@@ -29,12 +29,21 @@ If you are using :doc:`organization access tokens </overview/authentication>` or
 ``profileId`` parameter. Organizations can have multiple profiles for each of their websites. See
 :doc:`Profiles API </reference/v2/profiles-api/overview>` for more information.
 
+For these authentication methods the optional ``testmode`` parameter is available as well to enable test mode.
+
 .. parameter:: profileId
    :type: string
    :condition: required for access tokens
    :collapse: true
 
    The website profile's unique identifier, for example ``pfl_3RkSN1zuPE``.
+
+.. parameter:: testmode
+   :type: boolean
+   :condition: optional
+   :collapse: true
+
+   Set this to ``true`` to get a chargeback made in test mode. If you omit this parameter, you can only retrieve live mode chargebacks.
 
 Embedding of related resources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
To retrieve chargebacks of a payment in test mode using access tokens you need to specify it's test mode.