### PR TITLE
Update paypal-express-checkout-button.rst

### DIFF
--- a/source/orders/paypal-express-checkout-button.rst
+++ b/source/orders/paypal-express-checkout-button.rst
@@ -28,7 +28,7 @@ some small tweaks. You can use the following steps as a guideline for the basic 
 #. Place the button on the intended page, like a product page.
 
 #. Your website :doc:`creates an order </reference/v2/orders-api/create-order>` via the Orders API after the consumer
-   clicks the button. Make sure you set method to ``paypal`` so that the ``billingAddress`` field will not be required
+   clicks the button. Make sure you set the method to ``paypal`` so that the ``billingAddress`` field will not be required
    anymore.
 
    .. note:: Once the order is created, the amount can not be changed. When calculating shipping costs and/or taxes, be
@@ -38,11 +38,16 @@ some small tweaks. You can use the following steps as a guideline for the basic 
                 all, your request will result in an HTTP status code ``422 Unprocessable Entity``.
 
 #. Redirect your customer to the ``checkout`` URL which you can find in the response of the Create Order
-   API. The customer will select the address where the product(s) needs to be send to and completes the
+   API. The customer will select the address where the product(s) needs to be sent to and complete the
    payment.
 
-#. Mollie will receive the address from PayPal and adds it to the order. The consumer will be redirected
-   back to your website while we call your webhook, if set, to inform you about the latest order state.
+#. Mollie will receive the address from PayPal and updates the order's ``shippingAddress`` only if there is no 
+   ``shippingAddress`` set already. The consumer will  then be redirected back to your website while we call your webhook, 
+   if set, to inform you about the latest order state.
 
 #. You can retrieve the shipping address by calling the :doc:`Get order endpoint </reference/v2/orders-api/get-order>`
    and finish your order to ship the product(s).
+
+   .. warning:: PayPal returns the ``shippingAddress`` to us, but it does not return the ``billingAddress``. That info is not 
+      contained in the API response from PayPal, and we have no way of retrieving that. We instead use the ``shippingAddress``, 
+      returned to us by PayPal, as the order's ``billingAddress``.

--- a/source/orders/paypal-express-checkout-button.rst
+++ b/source/orders/paypal-express-checkout-button.rst
@@ -38,8 +38,8 @@ some small tweaks. You can use the following steps as a guideline for the basic 
                 all, your request will result in an HTTP status code ``422 Unprocessable Entity``.
 
 #. Redirect your customer to the ``checkout`` URL which you can find in the response of the Create Order
-   API. The customer will select the address where the product(s) needs to be sent to and complete the
-   payment.
+   API. The customer will select the address where the product(s) needs to be sent. Following this, the 
+   customer then completes the payment.
 
 #. Mollie will receive the address from PayPal and updates the order's ``shippingAddress`` only if there is no 
    ``shippingAddress`` set already. The consumer will  then be redirected back to your website while we call your webhook, 


### PR DESCRIPTION
This improves the PayPal express documentation on the propagation of shipping and billing addresses.

TECHSUP-3533