### PR TITLE
Python API client examples updated to v3

### DIFF
--- a/source/connect/getting-started.rst
+++ b/source/connect/getting-started.rst
@@ -29,7 +29,7 @@ Some examples:
 * `Authlib <https://github.com/lepture/authlib>`_ for Python, with support for common web frameworks like Flask and
   Django
 
-If your application is built with PHP, you can integrate it using the official `mollie/oauth2-mollie-php <https://github.com/mollie/oauth2-mollie-php>`_ package.
+If your application is built with PHP, you can integrate it using the official `mollie/oauth2-mollie-php <https://github.com/mollie/oauth2-mollie-php>`_ package. The `official Python client <https://github.com/mollie/mollie-api-python>`_ even supports OAuth out of the box.
 
 Once you have an OAuth compatible app running, let's register your app at Mollie next.
 

--- a/source/reference/v2/captures-api/get-capture.rst
+++ b/source/reference/v2/captures-api/get-capture.rst
@@ -156,9 +156,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      capture = mollie_client.captures.with_parent_id('tr_WDqYK6vllg').get('cpt_4qqhO89gsT')
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      capture = payment.captures.get("cpt_4qqhO89gsT")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/captures-api/list-captures.rst
+++ b/source/reference/v2/captures-api/list-captures.rst
@@ -111,9 +111,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      captures = mollie_client.captures.with_parent_id('tr_WDqYK6vllg').list()
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      captures = payment.captures.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/chargebacks-api/get-payment-chargeback.rst
+++ b/source/reference/v2/chargebacks-api/get-payment-chargeback.rst
@@ -189,10 +189,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payment = mollie_client.payments.get('tr_WDqYK6vllg')
-      chargeback = mollie_client.payment_chargebacks.on(payment).get('chb_n9z0tp')
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      chargeback = payment.chargebacks.get("chb_n9z0tp")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/chargebacks-api/list-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-chargebacks.rst
@@ -113,7 +113,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
       chargebacks = mollie_client.chargebacks.list()
 

--- a/source/reference/v2/chargebacks-api/list-payment-chargebacks.rst
+++ b/source/reference/v2/chargebacks-api/list-payment-chargebacks.rst
@@ -101,10 +101,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payment = mollie_client.payments.get('tr_WDqYK6vllg')
-      chargebacks = payment.chargebacks
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      chargebacks = payment.chargebacks.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/clients-api/get-client.rst
+++ b/source/reference/v2/clients-api/get-client.rst
@@ -81,11 +81,23 @@ Response
 
 Example
 -------
-.. code-block:: bash
-  :linenos:
+.. code-block-selector::
+   .. code-block:: bash
+      :linenos:
 
-  curl -X GET https://api.mollie.com/v2/clients/org_1337 \
-     -H "Authorization: Bearer access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+      curl -X GET https://api.mollie.com/v2/clients/org_1337 \
+         -H "Authorization: Bearer access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+   .. code-block:: python
+      :linenos:
+
+      from mollie.api.client import Client
+
+      mollie_client = Client()
+      mollie_client.set_access_token("access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      client = mollie_client.clients.get("org_1337")
+
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/clients-api/list-clients.rst
+++ b/source/reference/v2/clients-api/list-clients.rst
@@ -104,11 +104,22 @@ Response
 
 Example
 -------
-.. code-block:: bash
-  :linenos:
+.. code-block-selector::
+   .. code-block:: bash
+      :linenos:
 
-  curl -X GET https://api.mollie.com/v2/clients?limit=3 \
-     -H "Authorization: Bearer access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+      curl -X GET https://api.mollie.com/v2/clients?limit=3 \
+         -H "Authorization: Bearer access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+
+   .. code-block:: python
+      :linenos:
+
+      from mollie.api.client import Client
+
+      mollie_client = Client()
+      mollie_client.set_access_token("access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      client = mollie_client.clients.list()
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/customers-api/create-customer-payment.rst
+++ b/source/reference/v2/customers-api/create-customer-payment.rst
@@ -115,17 +115,19 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payment = mollie_client.customer_payments.with_parent_id('cst_8wmqcHMN4U').create(
-          data={
-      'amount': {'value': '10.00', 'currency': 'EUR'},
-              'description': 'Order #12345',
-              'sequenceType': 'first',
-              'redirectUrl': 'https://webshop.example.org/order/12345/',
-              'webhookUrl': 'https://webshop.example.org/payments/webhook/',
-          }
-      )
+      customer = mollie_client.customers.get("cst_8wmqcHMN4U")
+      payment = customer.payments.create({
+          "amount": {
+              "value": "10.00",
+              "currency": "EUR",
+          },
+          "description": "Order #12345",
+          "sequenceType": "first",
+          "redirectUrl": "https://webshop.example.org/order/12345/",
+          "webhookUrl": "https://webshop.example.org/payments/webhook/",
+      })
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/customers-api/create-customer.rst
+++ b/source/reference/v2/customers-api/create-customer.rst
@@ -94,11 +94,11 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
       customer = mollie_client.customers.create({
-        'name': 'Customer A',
-        'email': 'customer@example.org'
+          "name": "Customer A",
+          "email": "customer@example.org",
       })
 
    .. code-block:: ruby

--- a/source/reference/v2/customers-api/delete-customer.rst
+++ b/source/reference/v2/customers-api/delete-customer.rst
@@ -57,9 +57,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      mollie_client.customers.delete('cst_8wmqcHMN4U')
+      mollie_client.customers.delete("cst_8wmqcHMN4U")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/customers-api/get-customer.rst
+++ b/source/reference/v2/customers-api/get-customer.rst
@@ -143,9 +143,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXs")
 
-      customer = mollie_client.customers.get(customer_id='cst_8wmqcHMN4U')
+      customer = mollie_client.customers.get("cst_8wmqcHMN4U")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/customers-api/list-customer-payments.rst
+++ b/source/reference/v2/customers-api/list-customer-payments.rst
@@ -74,9 +74,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payments = mollie_client.customer_payments.with_parent_id('cst_8wmqcHMN4U').list()
+      customer = mollie_client.customers.get("cst_8wmqcHMN4U")
+      payments = customer.payments.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/customers-api/list-customers.rst
+++ b/source/reference/v2/customers-api/list-customers.rst
@@ -118,7 +118,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
       # First page
       customers = mollie_client.customers.list()

--- a/source/reference/v2/customers-api/update-customer.rst
+++ b/source/reference/v2/customers-api/update-customer.rst
@@ -98,9 +98,11 @@ Example
 
       customer = mollie_client.customers.update(
           "cst_8wmqcHMN4U",
-          data={"name": "Updated Customer A", "email": "updated-customer@example.org"},
+          {
+              "name": "Updated Customer A",
+              "email": "updated-customer@example.org"
+          },
       )
-
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/invoices-api/get-invoice.rst
+++ b/source/reference/v2/invoices-api/get-invoice.rst
@@ -201,9 +201,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      invoice = mollie_client.invoices.get('inv_xBEbP9rvAq')
+      invoice = mollie_client.invoices.get("inv_xBEbP9rvAq")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/invoices-api/list-invoices.rst
+++ b/source/reference/v2/invoices-api/list-invoices.rst
@@ -113,7 +113,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
       invoices = mollie_client.invoices.list()
 

--- a/source/reference/v2/mandates-api/create-mandate.rst
+++ b/source/reference/v2/mandates-api/create-mandate.rst
@@ -132,15 +132,16 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      mandate = mollie_client.customer_mandates.with_parent_id('cst_4qqhO89gsT').create({
-          'method': 'directdebit',
-          'consumerName': 'John Doe',
-          'consumerAccount': 'NL55INGB0000000000',
-          'consumerBic': 'INGBNL2A',
-          'signatureDate': '2020-04-23',
-          'mandateReference': 'YOUR-COMPANY-MD13804'
+      customer = mollie_client.customers.get("cst_4qqhO89gsT")
+      mandate = customer.mandates.create({
+          "method": "directdebit",
+          "consumerName": "John Doe",
+          "consumerAccount": "NL55INGB0000000000",
+          "consumerBic": "INGBNL2A",
+          "signatureDate": "2020-04-23",
+          "mandateReference": "YOUR-COMPANY-MD13804",
       })
 
    .. code-block:: ruby

--- a/source/reference/v2/mandates-api/get-mandate.rst
+++ b/source/reference/v2/mandates-api/get-mandate.rst
@@ -198,9 +198,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      mandate = mollie_client.customer_mandates.with_parent_id('cst_4qqhO89gsT').get('mdt_h3gAaD5zP')
+      customer = mollie_client.customers.get("cst_4qqhO89gsT")
+      mandate = customer.mandates.get("mdt_h3gAaD5zP")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/mandates-api/list-mandates.rst
+++ b/source/reference/v2/mandates-api/list-mandates.rst
@@ -115,9 +115,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      mandates = mollie_client.customer_mandates.with_parent_id('cst_stTC2WHAuS').list()
+      customer = mollie_client.customers.get("cst_4qqhO89gsT")
+      mandates = customer.mandates.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/mandates-api/revoke-mandate.rst
+++ b/source/reference/v2/mandates-api/revoke-mandate.rst
@@ -55,6 +55,17 @@ Example
       $mandate = $customer->getMandate("mdt_pWUnw6pkBN");
       $mandate->revoke();
 
+   .. code-block:: python
+      :linenos:
+
+      from mollie.api.client import Client
+
+      mollie_client = Client()
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      customer = mollie_client.customers.get("cst_4qqhO89gsT")
+      customer.mandates.delete("mdt_h3gAaD5zP")
+
    .. code-block:: ruby
       :linenos:
 
@@ -78,16 +89,6 @@ Example
           { customerId: 'cst_stTC2WHAuS' }
         );
       })();
-
-   .. code-block:: python
-      :linenos:
-
-      from mollie.api.client import Client
-
-      mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-
-      mandate = mollie_client.customer_mandates.with_parent_id('cst_4qqhO89gsT').delete('mdt_h3gAaD5zP')
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/methods-api/get-method.rst
+++ b/source/reference/v2/methods-api/get-method.rst
@@ -245,8 +245,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      mollie_client.methods.get('ideal', include='issuers,pricing')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      method = mollie_client.methods.get("ideal", include="issuers,pricing")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/methods-api/list-all-methods.rst
+++ b/source/reference/v2/methods-api/list-all-methods.rst
@@ -91,7 +91,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
       methods = mollie_client.methods.all()
 

--- a/source/reference/v2/methods-api/list-methods.rst
+++ b/source/reference/v2/methods-api/list-methods.rst
@@ -210,13 +210,16 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
       # Methods for the Payments API
       methods = mollie_client.methods.list()
 
       # Methods for the Orders API
-      methods = mollie_client.methods.list(resource='orders')
+      methods = mollie_client.methods.list(resource="orders")
+
+      # Methods including pricing
+      methods = mollie_client.methods.list(include="pricing")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/onboarding-api/get-onboarding-status.rst
+++ b/source/reference/v2/onboarding-api/get-onboarding-status.rst
@@ -107,9 +107,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_access_token("access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      onboarding = mollie_client.onboarding.get('me')
+      onboarding = mollie_client.onboarding.get("me")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/onboarding-api/submit-onboarding-data.rst
+++ b/source/reference/v2/onboarding-api/submit-onboarding-data.rst
@@ -237,31 +237,28 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_access_token("access_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      onboarding = mollie_client.onboarding.create(
-          'me',
-          data={
-              'organization': {
-                  'name': 'Mollie B.V.',
-                  'address': {
-                      'streetAndNumber': 'Keizersgracht 126',
-                      'postalCode': '1015 CW',
-                      'city': 'Amsterdam',
-                      'country': 'NL',
-                  },
-                  'registrationNumber': '30204462',
-                  'vatNumber': 'NL815839091B01',
+      onboarding = mollie_client.onboarding.create({
+          "organization": {
+              "name": "Mollie B.V.",
+              "address": {
+                  "streetAndNumber": "Keizersgracht 126",
+                  "postalCode": "1015 CW",
+                  "city": "Amsterdam",
+                  "country": "NL",
               },
-              'profile': {
-                  'name': 'Mollie',
-                  'url': 'https://www.mollie.com',
-                  'email': 'info@mollie.com',
-                  'phone': '+31208202070',
-                  'businessCategory': 'MONEY_SERVICES',
-              },
+              "registrationNumber": "30204462",
+              "vatNumber": "NL815839091B01",
           },
-      )
+          "profile": {
+              "name": "Mollie",
+              "url": "https://www.mollie.com",
+              "email": "info@mollie.com",
+              "phone": "+31208202070",
+              "categoryCode": 6012,
+          },
+      })
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/orders-api/cancel-order-lines.rst
+++ b/source/reference/v2/orders-api/cancel-order-lines.rst
@@ -144,21 +144,27 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_8wmqcHMN4U')
-      order.cancel_lines({
-        'lines': [
-          {
-            'id': 'odl_dgtxyl',
-            'quantity': 1,  # you can partially cancel the line.
-          }
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_8wmqcHMN4U")
+
+      # To cancel a single line, simply delete it by id:
+      order.lines.delete("odl_dgtxyl")
+
+      # To partially cancel a line, change its quantity:
+      order.lines.delete_lines({
+        "lines": [
+            {
+                "id": "odl_dgtxyl",
+                "quantity": 1,
+            }
         ]
       })
 
-      # if you want to cancel all eligible lines, you can use this shorthand:
-      # order.cancel_lines()
+      # If you want to cancel all eligible lines, you can use this shorthand:
+      order.lines.delete_lines()
 
-      updated_order = mollie_client.orders.get('ord_8wmqcHMN4U')
+      updated_order = mollie_client.orders.get("ord_8wmqcHMN4U")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/orders-api/cancel-order.rst
+++ b/source/reference/v2/orders-api/cancel-order.rst
@@ -74,8 +74,9 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.delete('ord_8wmqcHMN4U')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.delete("ord_8wmqcHMN4U")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/orders-api/create-order-payment.rst
+++ b/source/reference/v2/orders-api/create-order-payment.rst
@@ -135,10 +135,12 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      order = mollie_client.orders.get('ord_stTC2WHAuS')
-      order = order.create_payment(data={'method': 'banktransfer'})
+      order = mollie_client.orders.get("ord_stTC2WHAuS")
+      payment = order.payments.create({
+          "method": "banktransfer",
+      })
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -783,74 +783,102 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      order = mollie_client.orders.create(
-          {
-              'amount': {'value': '1027.99', 'currency': 'EUR'},
-              'billingAddress': {
-                  'organizationName': 'Mollie B.V.',
-                  'streetAndNumber': 'Keizersgracht 126',
-                  'city': 'Amsterdam',
-                  'region': 'Noord-Holland',
-                  'postalCode': '1234AB',
-                  'country': 'NL',
-                  'title': 'Dhr.',
-                  'givenName': 'Piet',
-                  'familyName': 'Mondriaan',
-                  'email': 'piet@mondriaan.com',
-                  'phone': '+31309202070',
-              },
-              'shippingAddress': {
-                  'organizationName': 'Mollie B.V.',
-                  'streetAndNumber': 'Prinsengracht 126',
-                  'streetAdditional': '4th floor',
-                  'city': 'Haarlem',
-                  'region': 'Noord-Holland',
-                  'postalCode': '5678AB',
-                  'country': 'NL',
-                  'title': 'Mr.',
-                  'givenName': 'Chuck',
-                  'familyName': 'Norris',
-                  'email': 'norris@chucknorrisfacts.net',
-              },
-              'metadata': {'order_id': '1337', 'description': 'Lego cars'},
-              'consumerDateOfBirth': '1958-01-31',
-              'locale': 'nl_NL',
-              'orderNumber': '1337',
-              'redirectUrl': 'https://example.org/redirect',
-              'webhookUrl': 'https://example.org/webhook',
-              'method': 'klarnapaylater',
-              'lines': [
-                  {
-                      'type': 'physical',
-                      'sku': '5702016116977',
-                      'name': 'LEGO 42083 Bugatti Chiron',
-                      'productUrl': 'https://shop.lego.com/nl-NL/Bugatti-Chiron-42083',
-                      'imageUrl': 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$',
-                      'metadata': {'order_id': '1337', 'description': 'Bugatti Chiron'},
-                      'quantity': 2,
-                      'vatRate': '21.00',
-                      'unitPrice': {'currency': 'EUR', 'value': '399.00'},
-                      'totalAmount': {'currency': 'EUR', 'value': '698.00'},
-                      'discountAmount': {'currency': 'EUR', 'value': '100.00'},
-                      'vatAmount': {'currency': 'EUR', 'value': '121.14'},
+      order = mollie_client.orders.create({
+          "amount": {
+              "value": "1027.99",
+              "currency": "EUR",
+          },
+          "billingAddress": {
+              "organizationName": "Mollie B.V.",
+              "streetAndNumber": "Keizersgracht 126",
+              "city": "Amsterdam",
+              "region": "Noord-Holland",
+              "postalCode": "1234AB",
+              "country": "NL",
+              "title": "Dhr.",
+              "givenName": "Piet",
+              "familyName": "Mondriaan",
+              "email": "piet@mondriaan.com",
+              "phone": "+31309202070",
+          },
+          "shippingAddress": {
+              "organizationName": "Mollie B.V.",
+              "streetAndNumber": "Prinsengracht 126",
+              "streetAdditional": "4th floor",
+              "city": "Haarlem",
+              "region": "Noord-Holland",
+              "postalCode": "5678AB",
+              "country": "NL",
+              "title": "Mr.",
+              "givenName": "Chuck",
+              "familyName": "Norris",
+              "email": "norris@chucknorrisfacts.net",
+          },
+          "metadata": {
+              "order_id": "1337",
+              "description": "Lego cars",
+          },
+          "consumerDateOfBirth": "1958-01-31",
+          "locale": "nl_NL",
+          "orderNumber": "1337",
+          "redirectUrl": "https://example.org/redirect",
+          "webhookUrl": "https://example.org/webhook",
+          "method": "klarnapaylater",
+          "lines": [
+              {
+                  "type": "physical",
+                  "sku": "5702016116977",
+                  "name": "LEGO 42083 Bugatti Chiron",
+                  "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                  "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                  "metadata": {
+                      "order_id": "1337",
+                      "description": "Bugatti Chiron",
                   },
-                  {
-                      'type': 'physical',
-                      'sku': '5702015594028',
-                      'name': 'LEGO 42056 Porsche 911 GT3 RS',
-                      'productUrl': 'https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056',
-                      'imageUrl': 'https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$',
-                      'quantity': 1,
-                      'vatRate': '21.00',
-                      'unitPrice': {'currency': 'EUR', 'value': '329.99'},
-                      'totalAmount': {'currency': 'EUR', 'value': '329.99'},
-                      'vatAmount': {'currency': 'EUR', 'value': '57.27'},
+                  "quantity": 2,
+                  "vatRate": "21.00",
+                  "unitPrice": {
+                      "currency": "EUR",
+                      "value": "399.00",
                   },
-              ],
-          }
-      )
+                  "totalAmount": {
+                      "currency": "EUR",
+                      "value": "698.00",
+                  },
+                  "discountAmount": {
+                      "currency": "EUR",
+                      "value": "100.00",
+                  },
+                  "vatAmount": {
+                      "currency": "EUR",
+                      "value": "121.14"
+                  },
+              },
+              {
+                  "type": "physical",
+                  "sku": "5702015594028",
+                  "name": "LEGO 42056 Porsche 911 GT3 RS",
+                  "productUrl": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+                  "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+                  "quantity": 1,
+                  "vatRate": "21.00",
+                  "unitPrice": {
+                      "currency": "EUR",
+                      "value": "329.99",
+                  },
+                  "totalAmount": {
+                      "currency": "EUR",
+                      "value": "329.99",
+                  },
+                  "vatAmount": {
+                      "currency": "EUR",
+                      "value": "57.27",
+                  },
+              },
+          ],
+      })
 
 
    .. code-block:: ruby

--- a/source/reference/v2/orders-api/get-order.rst
+++ b/source/reference/v2/orders-api/get-order.rst
@@ -522,8 +522,9 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_stTC2WHAuS')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_stTC2WHAuS", embed="payment,refunds")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/orders-api/list-orders.rst
+++ b/source/reference/v2/orders-api/list-orders.rst
@@ -125,7 +125,8 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
       most_recent_orders = mollie_client.orders.list()
       previous_orders = most_recent_orders.get_next()
 

--- a/source/reference/v2/orders-api/update-order-line.rst
+++ b/source/reference/v2/orders-api/update-order-line.rst
@@ -197,23 +197,14 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
       order = mollie_client.orders.get('ord_pbjz8x')
-      order = order.update_line(
-          'odl_dgtxyl',
-          data={
-      'name': 'LEGO 71043 Hogwarts™ Castle',
-              'productUrl': 'https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043',
-              'imageUrl': 'https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$',
-              'quantity': 2,
-              'vatRate': '21.00',
-              'unitPrice': {'currency': 'EUR', 'value': '349.00'},
-              'totalAmount': {'currency': 'EUR', 'value': '598.00'},
-              'discountAmount': {'currency': 'EUR', 'value': '100.00'},
-              'vatAmount': {'currency': 'EUR', 'value': '103.79'},
-          },
-      )
+      order = order.lines.update("odl_dgtxyl", {
+          "name": "LEGO 71043 Hogwarts™ Castle",
+          "productUrl": "https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043",
+          "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$",
+      })
 
    .. code-block:: javascript
       :linenos:

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -271,22 +271,23 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      mollie_client.order.update('ord_kEn1PlbGa', {
-        'billingAddress': {
-            'organizationName': 'Mollie B.V.',
-            'streetAndNumber': 'Keizersgracht 126',
-            'city': 'Amsterdam',
-            'region': 'Noord-Holland',
-            'postalCode': '1234AB',
-            'country': 'NL',
-            'title': 'Dhr',
-            'givenName': 'Piet',
-            'familyName': 'Mondriaan',
-            'email': 'piet@mondriaan.com',
-            'phone': '+31208202070'
-        }
-      }
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      mollie_client.order.update("ord_kEn1PlbGa", {
+          "billingAddress": {
+              "organizationName": "Mollie B.V.",
+              "streetAndNumber": "Keizersgracht 126",
+              "city": "Amsterdam",
+              "region": "Noord-Holland",
+              "postalCode": "1234AB",
+              "country": "NL",
+              "title": "Dhr",
+              "givenName": "Piet",
+              "familyName": "Mondriaan",
+              "email": "piet@mondriaan.com",
+              "phone": "+31208202070",
+          }
+      })
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/organizations-api/current-organization.rst
+++ b/source/reference/v2/organizations-api/current-organization.rst
@@ -111,9 +111,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      organization = mollie_client.organizations.get('me')
+      organization = mollie_client.organizations.get("me")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/organizations-api/get-organization.rst
+++ b/source/reference/v2/organizations-api/get-organization.rst
@@ -112,9 +112,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      organization = mollie_client.organizations.get('org_12345678')
+      organization = mollie_client.organizations.get("org_12345678")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/payment-links-api/create-payment-link.rst
+++ b/source/reference/v2/payment-links-api/create-payment-link.rst
@@ -144,6 +144,7 @@ Example
 
       mollie_client = Client()
       mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
       payment_link = mollie_client.payment_links.create({
          "amount": {
                "currency": "EUR",

--- a/source/reference/v2/payment-links-api/get-payment-link.rst
+++ b/source/reference/v2/payment-links-api/get-payment-link.rst
@@ -152,6 +152,7 @@ Example
 
       mollie_client = Client()
       mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
       payment_link = mollie_client.payment_links.get("pl_4Y0eZitmBnQ6IDoMqZQKh")
 
 Response

--- a/source/reference/v2/payment-links-api/list-payment-links.rst
+++ b/source/reference/v2/payment-links-api/list-payment-links.rst
@@ -124,6 +124,7 @@ Example
 
       mollie_client = Client()
       mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
       payment_links = mollie_client.payment_links.list()
 
 Response

--- a/source/reference/v2/payments-api/cancel-payment.rst
+++ b/source/reference/v2/payments-api/cancel-payment.rst
@@ -64,8 +64,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      canceled_payment = mollie_client.payments.delete('tr_WDqYK6vllg')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      canceled_payment = mollie_client.payments.delete("tr_WDqYK6vllg")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -771,18 +771,18 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
       payment = mollie_client.payments.create({
-         'amount': {
-               'currency': 'EUR',
-               'value': '10.00'
-         },
-         'description': 'Order #12345',
-         'redirectUrl': 'https://webshop.example.org/order/12345/',
-         'webhookUrl': 'https://webshop.example.org/payments/webhook/',
-         'metadata': {
-               'order_id': '12345'
-         }
+          "amount": {
+              "currency": "EUR",
+              "value": "10.00",
+          },
+          "description": "Order #12345",
+          "redirectUrl": "https://webshop.example.org/payments/webhook/",
+          "webhookUrl": "https://webshop.example.org/order/12345/",
+          "metadata": {
+              "order_id": "12345",
+          }
       })
 
    .. code-block:: ruby

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -1144,8 +1144,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      payment = mollie_client.payments.get('tr_WDqYK6vllg')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      payment = mollie_client.payments.get("tr_WDqYK6vllg", embed="refunds,chargebacks", include="details.qrCode")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/payments-api/list-payments.rst
+++ b/source/reference/v2/payments-api/list-payments.rst
@@ -148,12 +148,12 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      # get the first page
+      # Get the first page
       payments = mollie_client.payments.list()
 
-      # get the next page
+      # Get the next page
       next_payments = payments.get_next()
 
    .. code-block:: ruby

--- a/source/reference/v2/payments-api/update-payment.rst
+++ b/source/reference/v2/payments-api/update-payment.rst
@@ -178,12 +178,15 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
       payment = mollie_client.payments.update("tr_7UhSN1zuXS", {
-        'description': 'Order #98765',
-        'redirectUrl': 'https://webshop.example.org/order/98765/',
-        'webhookUrl': 'https://webshop.example.org/payments/webhook/',
-        'metadata': {'order_id': '98765'}
+          "description": "Order #98765",
+          "webhookUrl": "https://webshop.example.org/order/98765/",
+          "redirectUrl": "https://webshop.example.org/payments/webhook/",
+          "metadata": {
+              "order_id": "98765",
+          }
       })
 
    .. code-block:: ruby

--- a/source/reference/v2/permissions-api/get-permission.rst
+++ b/source/reference/v2/permissions-api/get-permission.rst
@@ -82,9 +82,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      permissions = mollie_client.permissions.get('payments.read')
+      permission = mollie_client.permissions.get("payments.read")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/permissions-api/list-permissions.rst
+++ b/source/reference/v2/permissions-api/list-permissions.rst
@@ -77,7 +77,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
       permissions = mollie_client.permissions.list()
 

--- a/source/reference/v2/profiles-api/create-profile.rst
+++ b/source/reference/v2/profiles-api/create-profile.rst
@@ -144,18 +144,16 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      profile = mollie_client.profiles.create(
-          data={
-              'name': 'My website name',
-              'website': 'https://www.mywebsite.com',
-              'email': 'info@mywebsite.com',
-              'phone': '+31208202070',
-              'businessCategory': 'OTHER_MERCHANDISE',
-              'mode': 'live',
-          }
-      )
+      profile = mollie_client.profiles.create({
+          "name": "My website name",
+          "website": "https://www.mywebsite.com",
+          "email": "info@mywebsite.com",
+          "phone": "+31208202070",
+          "businessCategory": "OTHER_MERCHANDISE",
+          "mode": "live",
+      })
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/profiles-api/delete-profile.rst
+++ b/source/reference/v2/profiles-api/delete-profile.rst
@@ -45,9 +45,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      mollie_client.profiles.delete('pfl_v9hTwCvYqw')
+      mollie_client.profiles.delete("pfl_v9hTwCvYqw")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/profiles-api/disable-gift-card-issuer.rst
+++ b/source/reference/v2/profiles-api/disable-gift-card-issuer.rst
@@ -50,9 +50,10 @@ Request
      from mollie.api.client import Client
 
      mollie_client = Client()
-     mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+     mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-     mollie_client.profile_methods.with_parent_id('pfl_v9hTwCvYqw', 'giftcard').delete('festivalcadeau')
+     profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
+     profile.methods.disable_issuer("giftcard", "festivalcadeau")
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/disable-method.rst
+++ b/source/reference/v2/profiles-api/disable-method.rst
@@ -63,9 +63,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      mollie_client.profile_methods.with_parent_id('pfl_v9hTwCvYqw', 'ideal').delete()
+      profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
+      profile.methods.delete("ideal")
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/disable-voucher-issuer.rst
+++ b/source/reference/v2/profiles-api/disable-voucher-issuer.rst
@@ -50,9 +50,10 @@ Request
      from mollie.api.client import Client
 
      mollie_client = Client()
-     mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+     mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-     mollie_client.profile_methods.with_parent_id('pfl_v9hTwCvYqw', 'voucher').delete('appetiz')
+     profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
+     profile.methods.disable_issuer("voucher", "appetiz")
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/enable-gift-card-issuer.rst
+++ b/source/reference/v2/profiles-api/enable-gift-card-issuer.rst
@@ -89,9 +89,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      mollie_client.profile_methods.with_parent_id('pfl_v9hTwCvYqw', 'giftcard').create('festivalcadeau')
+      profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
+      issuer = profile.methods.enable_issuer("giftcard", "festivalcadeau")
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/enable-method.rst
+++ b/source/reference/v2/profiles-api/enable-method.rst
@@ -69,9 +69,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      mollie_client.profile_methods.with_parent_id('pfl_v9hTwCvYqw', 'ideal').create()
+      profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
+      method = profile.methods.enable("ideal")
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/enable-voucher-issuer.rst
+++ b/source/reference/v2/profiles-api/enable-voucher-issuer.rst
@@ -114,11 +114,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      mollie_client.profile_methods.with_parent_id('pfl_v9hTwCvYqw', 'voucher').create(
-          'appetiz', data={'contractId': 'abc123'}
-      )
+      profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
+      issuer = profile.methods.enable_issuer("voucher", "appetiz", {"contractId": "abc123"})
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/get-profile-me.rst
+++ b/source/reference/v2/profiles-api/get-profile-me.rst
@@ -52,9 +52,9 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      profile = mollie_client.profiles.get('me')
+      profile = mollie_client.profiles.get("me")
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/profiles-api/get-profile.rst
+++ b/source/reference/v2/profiles-api/get-profile.rst
@@ -211,9 +211,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      profile = mollie_client.profiles.get('pfl_v9hTwCvYqw')
+      profile = mollie_client.profiles.get("pfl_v9hTwCvYqw")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/profiles-api/list-profiles.rst
+++ b/source/reference/v2/profiles-api/list-profiles.rst
@@ -101,7 +101,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
       profiles = mollie_client.profiles.list()
 

--- a/source/reference/v2/profiles-api/update-profile.rst
+++ b/source/reference/v2/profiles-api/update-profile.rst
@@ -146,17 +146,16 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
       profile = mollie_client.profiles.update(
-          'pfl_v9hTwCvYqw',
-          data={
-              'name': 'My website name - Update 1',
-              'website': 'https://www.mywebsite2.com',
-              'email': 'info@mywebsite2.com',
-              'phone': '+31208202070',
-              'businessCategory': 'OTHER_MERCHANDISE',
-          },
+          "pfl_v9hTwCvYqw", {
+              "name": "My website name - Update 1",
+              "website": "https://www.mywebsite2.com",
+              "email": "info@mywebsite2.com",
+              "phone": "+31208202070",
+              "businessCategory": "OTHER_MERCHANDISE",
+          }
       )
 
    .. code-block:: ruby

--- a/source/reference/v2/refunds-api/cancel-payment-refund.rst
+++ b/source/reference/v2/refunds-api/cancel-payment-refund.rst
@@ -65,10 +65,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payment = mollie_client.payments.get('tr_WDqYK6vllg')
-      mollie_client.payment_refunds.on(payment).delete('re_4qqhO89gsT')
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      payment.refunds.delete("re_4qqhO89gsT")
 
    .. code-block:: javascript
       :linenos:

--- a/source/reference/v2/refunds-api/create-order-refund.rst
+++ b/source/reference/v2/refunds-api/create-order-refund.rst
@@ -151,18 +151,19 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_stTC2WHAuS')
-      order.create_refund({
-        'lines': [
-          'id': 'odl_dgtxyl',
-          'quantity': 1,
-        ],
-        'description': 'Required quantity not in stock, refunding one photo book.'
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_stTC2WHAuS")
+      refund = order.refunds.create({
+          "lines": [
+              "id": "odl_dgtxyl",
+              "quantity": 1,
+          ],
+          "description": "Required quantity not in stock, refunding one photo book.",
       })
 
       # Alternative shorthand for refunding all eligible order lines
-      order.create_refund()
+      refund = order.refunds.create()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/refunds-api/create-payment-refund.rst
+++ b/source/reference/v2/refunds-api/create-payment-refund.rst
@@ -178,14 +178,14 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payment = mollie_client.payments.get('tr_WDqYK6vllg')
-      refund = mollie_client.payment_refunds.on(payment).create({
-         'amount': {
-               'value': '5.95',
-               'currency': 'EUR'
-         }
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      refund = payment.refunds.create({
+          "amount": {
+              "value": "5.95",
+              "currency": "EUR",
+          }
       })
 
    .. code-block:: ruby

--- a/source/reference/v2/refunds-api/get-payment-refund.rst
+++ b/source/reference/v2/refunds-api/get-payment-refund.rst
@@ -236,10 +236,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      payment = mollie_client.payments.get('tr_WDqYK6vllg')
-      refund = mollie_client.payment_refunds.on(payment).get('re_4qqhO89gsT')
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      refund = payment.refunds.get("re_4qqhO89gsT")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/refunds-api/list-order-refunds.rst
+++ b/source/reference/v2/refunds-api/list-order-refunds.rst
@@ -122,9 +122,10 @@ Example
       :linenos:
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_stTC2WHAuS')
-      refunds = order.refunds()
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_stTC2WHAuS")
+      refunds = order.refunds.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/refunds-api/list-payment-refunds.rst
+++ b/source/reference/v2/refunds-api/list-payment-refunds.rst
@@ -123,8 +123,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      refunds = mollie_client.payments.get('tr_WDqYK6vllg').refunds
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      payment = mollie_client.payments.get("tr_WDqYK6vllg")
+      refunds = payment.refunds.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/refunds-api/list-refunds.rst
+++ b/source/reference/v2/refunds-api/list-refunds.rst
@@ -134,8 +134,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      refunds = mollie_client.refunds
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      refunds = mollie_client.refunds.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/get-next-settlement.rst
+++ b/source/reference/v2/settlements-api/get-next-settlement.rst
@@ -43,9 +43,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      settlement = mollie_client.settlements.get('next')
+      settlement = mollie_client.settlements.get("next")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/get-open-settlement.rst
+++ b/source/reference/v2/settlements-api/get-open-settlement.rst
@@ -44,9 +44,9 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      settlement = mollie_client.settlements.get('open')
+      settlement = mollie_client.settlements.get("open")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/get-settlement.rst
+++ b/source/reference/v2/settlements-api/get-settlement.rst
@@ -343,13 +343,12 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      settlement = mollie_client.settlements.get('stl_jDk30akdN')
+      settlement = mollie_client.settlements.get("stl_jDk30akdN")
 
       # or, by bank reference
-
-      settlement = mollie_client.settlements.get('1234567.1804.03')
+      settlement = mollie_client.settlements.get("1234567.1804.03")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/list-settlement-captures.rst
+++ b/source/reference/v2/settlements-api/list-settlement-captures.rst
@@ -102,9 +102,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      captures = mollie_client.settlement_captures.with_parent_id('stl_jDk30akdN').list()
+      settlement = mollie_client.settlements.get("stl_jDk30akdN")
+      captures = settlement.captures.list()
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/settlements-api/list-settlement-chargebacks.rst
+++ b/source/reference/v2/settlements-api/list-settlement-chargebacks.rst
@@ -63,9 +63,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      chargebacks = mollie_client.settlement_chargebacks.with_parent_id('stl_jDk30akdN').list()
+      settlement = mollie_client.settlements.get("stl_jDk30akdN")
+      chargebacks = settlement.chargebacks.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/list-settlement-payments.rst
+++ b/source/reference/v2/settlements-api/list-settlement-payments.rst
@@ -59,9 +59,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      payments = mollie_client.settlement_payments.with_parent_id('stl_jDk30akdN').list()
+      settlement = mollie_client.settlements.get("stl_jDk30akdN")
+      payments = settlement.payments.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/list-settlement-refunds.rst
+++ b/source/reference/v2/settlements-api/list-settlement-refunds.rst
@@ -62,9 +62,10 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
-      refunds = mollie_client.settlement_refunds.with_parent_id('stl_jDk30akdN').list()
+      settlement = mollie_client.settlements.get("stl_jDk30akdN")
+      refunds = settlement.refunds.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/settlements-api/list-settlements.rst
+++ b/source/reference/v2/settlements-api/list-settlements.rst
@@ -101,7 +101,7 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_access_token('access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ')
+      mollie_client.set_access_token("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ")
 
       settlements = mollie_client.settlements.list()
 

--- a/source/reference/v2/shipments-api/create-shipment.rst
+++ b/source/reference/v2/shipments-api/create-shipment.rst
@@ -174,37 +174,40 @@ Example
    .. code-block:: python
       :linenos:
 
+      from mollie.api.client import Client
+
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_kEn1PlbGa')
-      shipment = order.create_shipment({
-         'lines': [
-            {
-               'id': 'odl_dgtxyl',
-               'quantity': 1,  # you can set the quantity if not all is shipped at once
-            },
-            {
-               'id': 'odl_jp31jz',  # all is shipped if no quantity is set
-            }
-         ],
-         'tracking': {
-            'carrier': 'PostNL',
-            'code': '3SKABA000000000',
-            'url': 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C',
-         }
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_kEn1PlbGa")
+      shipment = order.shipments.create({
+          "lines": [
+              {
+                  "id": "odl_dgtxyl",
+                  "quantity": 1,  # you can set the quantity if not all is shipped at once
+              },
+              {
+                  "id": "odl_jp31jz",  # all is shipped if no quantity is set
+              }
+          ],
+          "tracking": {
+              "carrier": "PostNL",
+              "code": "3SKABA000000000",
+              "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C",
+          }
       })
 
       # if all lines are shipped, there is no need to specify them
       shipment = order.create_shipment({
-         'tracking': {
-            'carrier': 'PostNL',
-            'code': '3SKABA000000000',
-            'url': 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C',
-         }
+          "tracking": {
+              "carrier": "PostNL",
+              "code": "3SKABA000000000",
+              "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C",
+          }
       })
 
-      # or when no tracking is specified:
-      shipment = order.create_shipment()
+      # or, when no tracking is specified:
+      shipment = order.shipments.create()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/shipments-api/get-shipment.rst
+++ b/source/reference/v2/shipments-api/get-shipment.rst
@@ -128,10 +128,13 @@ Example
    .. code-block:: python
       :linenos:
 
+      from mollie.api.client import Client
+
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_kEn1PlbGa')
-      shipment = order.get_shipment('shp_3wmsgCJN4U')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_kEn1PlbGa")
+      shipment = order.shipments.get("shp_3wmsgCJN4U")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/shipments-api/list-shipments.rst
+++ b/source/reference/v2/shipments-api/list-shipments.rst
@@ -87,10 +87,13 @@ Example
    .. code-block:: python
       :linenos:
 
+      from mollie.api.client import Client
+
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_kEn1PlbGa')
-      shipments = order.shipments
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_kEn1PlbGa")
+      shipments = order.shipments.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/shipments-api/update-shipment.rst
+++ b/source/reference/v2/shipments-api/update-shipment.rst
@@ -101,14 +101,17 @@ Example
    .. code-block:: python
       :linenos:
 
+      from mollie.api.client import Client
+
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
-      order = mollie_client.orders.get('ord_kEn1PlbGa')
-      order.update_shipment('shp_3wmsgCJN4U', {
-         'tracking': {
-            'carrier': 'PostNL',
-            'code': '3SKABA000000000',
-            'url': 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C,
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
+      order = mollie_client.orders.get("ord_kEn1PlbGa")
+      shipment = order.shipments.update("shp_3wmsgCJN4U", {
+         "tracking": {
+            "carrier": "PostNL",
+            "code": "3SKABA000000000",
+            "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C,
          },
       })
 

--- a/source/reference/v2/subscriptions-api/cancel-subscription.rst
+++ b/source/reference/v2/subscriptions-api/cancel-subscription.rst
@@ -63,9 +63,10 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      mollie_client.customer_subscriptions.with_parent_id('cst_stTC2WHAuS').delete('sub_rVKGtNd6s3')
+      customer = mollie_client.customers.get("cst_stTC2WHAuS")
+      customer.subscriptions.delete("sub_rVKGtNd6s3")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/subscriptions-api/create-subscription.rst
+++ b/source/reference/v2/subscriptions-api/create-subscription.rst
@@ -194,17 +194,19 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      subscription = mollie_client.customer_subscriptions.with_parent_id('cst_stTC2WHAuS').create(
-          data={
-      'amount': {'currency': 'EUR', 'value': '25.00'},
-              'times': 4,
-              'interval': '3 months',
-              'description': 'Quarterly payment',
-              'webhookUrl': 'https://webshop.example.org/subscriptions/webhook/',
-          }
-      )
+      customer = mollie_client.customers.get("cst_stTC2WHAuS")
+      subscription = customer.subscriptions.create({
+          "amount": {
+              "currency": "EUR",
+              "value": "25.00",
+          },
+          "times": 4,
+          "interval": "3 months",
+          "description": "Quarterly payment",
+          "webhookUrl": "https://webshop.example.org/subscriptions/webhook/",
+      })
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/subscriptions-api/get-subscription.rst
+++ b/source/reference/v2/subscriptions-api/get-subscription.rst
@@ -225,7 +225,8 @@ Example
       mollie_client = Client()
       mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      subscription = mollie_client.customer_subscriptions.with_parent_id('cst_stTC2WHAuS').get('sub_rVKGtNd6s3')
+      customer = mollie_client.customers.get("cst_stTC2WHAuS")
+      subscription = customer.subscriptions.get("sub_rVKGtNd6s3")
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/subscriptions-api/list-all-subscriptions.rst
+++ b/source/reference/v2/subscriptions-api/list-all-subscriptions.rst
@@ -129,7 +129,8 @@ Example
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
+
       subscriptions = mollie_client.subscriptions.list()
 
 Response

--- a/source/reference/v2/subscriptions-api/list-subscription-payments.rst
+++ b/source/reference/v2/subscriptions-api/list-subscription-payments.rst
@@ -109,10 +109,11 @@ Request
       from mollie.api.client import Client
 
       mollie_client = Client()
-      mollie_client.set_api_key('test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM')
+      mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      subscription = mollie_client.customer_subscriptions.with_parent_id('cst_8wmqcHMN4U').get('sub_8JfGzs6v3K')
-      payments = subscription.payments
+      customer = mollie_client.customers.get("cst_stTC2WHAuS")
+      subscription = customer.subscriptions.get("sub_8JfGzs6v3K")
+      payments = subscription.payments.list()
 
 Response
 ^^^^^^^^

--- a/source/reference/v2/subscriptions-api/list-subscriptions.rst
+++ b/source/reference/v2/subscriptions-api/list-subscriptions.rst
@@ -129,7 +129,8 @@ Example
       mollie_client = Client()
       mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      subscriptions = mollie_client.customer_subscriptions.with_parent_id('cst_8wmqcHMN4U').list()
+      customer = mollie_client.customers.get("cst_stTC2WHAuS")
+      subscriptions = customer.subscriptions.list()
 
    .. code-block:: ruby
       :linenos:

--- a/source/reference/v2/subscriptions-api/update-subscription.rst
+++ b/source/reference/v2/subscriptions-api/update-subscription.rst
@@ -157,12 +157,11 @@ Example
       mollie_client = Client()
       mollie_client.set_api_key("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")
 
-      subscription = mollie_client.customer_subscriptions.with_parent_id(
-          "cst_8wmqcHMN4U"
-      ).update(
+      customer = mollie_client.customers.get("cst_stTC2WHAuS")
+      subscription = customer.subscriptions.update(
           "sub_8EjeBVgtEn",
-          data={
-      "amount": {
+          {
+              "amount": {
                   "currency": "EUR",
                   "value": "10.00",
               },


### PR DESCRIPTION
We are quickly working towards a new major version of the [Python API client](https://github.com/mollie/mollie-api-python), which has some big breaking changes in the API. This PR updates all example code in the docs to the new client API.

NOTE: This PR should be merged after the release of the client (hence: draft PR). Please review earlier and send your comments.