### PR TITLE
Php update calls

### DIFF
--- a/source/reference/v2/customers-api/update-customer.rst
+++ b/source/reference/v2/customers-api/update-customer.rst
@@ -83,10 +83,11 @@ Example
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
 
-      $customer = $mollie->customers->get("cst_8wmqcHMN4U");
-      $customer->name = "Updated Customer A";
-      $customer->email = "updated-customer@example.org";
-      $customer->update();
+      $customerId = "cst_8wmqcHMN4U";
+      $customer = $mollie->customers->update($customerId, [
+        "name" => "Updated Customer A",
+        "email" => "updated-customer@example.org",
+      ]);
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/orders-api/update-order-line.rst
+++ b/source/reference/v2/orders-api/update-order-line.rst
@@ -191,6 +191,40 @@ Example
                }
          }'
 
+    .. code-block:: php
+      :linenos:
+
+      <?php
+      $mollie = new \Mollie\Api\MollieApiClient();
+      $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
+
+      $orderId = "ord_pbjz8x";
+      $orderLineId = "odl_dgtxyl";
+      $mollie->orderLines->update($orderId, $orderLineId, [
+        "name" => "LEGO 71043 Hogwarts™ Castle",
+        "productUrl" => "https://shop.lego.com/en-GB/product/Hogwarts-Castle-71043",
+        "imageUrl" => "https://sh-s7-live-s.legocdn.com/is/image//LEGO/71043_alt1?$main$",
+        "quantity" => 2,
+        "vatRate" => "21.00",
+        "unitPrice" => [
+          "currency" => "EUR",
+          "value" => "349.00"
+        ],
+        "totalAmount" => [
+          "currency" => "EUR",
+          "value" => "598.00"
+        ],
+        "discountAmount" => [
+          "currency" => "EUR",
+          "value" => "100.00"
+        ],
+        "vatAmount" => [
+          "currency" => "EUR",
+          "value" => "103.79"
+        ]
+      ]);
+
+
    .. code-block:: python
       :linenos:
 

--- a/source/reference/v2/orders-api/update-order.rst
+++ b/source/reference/v2/orders-api/update-order.rst
@@ -253,19 +253,22 @@ Example
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
 
-      $order = $mollie->orders->get("ord_kEn1PlbGa");
-      $order->billingAddress->organizationName = "Mollie B.V.";
-      $order->billingAddress->streetAndNumber = "Keizersgracht 126";
-      $order->billingAddress->city = "Amsterdam";
-      $order->billingAddress->region = "Noord-Holland";
-      $order->billingAddress->postalCode = "1234AB";
-      $order->billingAddress->country = "NL";
-      $order->billingAddress->title = "Dhr";
-      $order->billingAddress->givenName = "Piet";
-      $order->billingAddress->familyName = "Mondriaan";
-      $order->billingAddress->email = "piet@mondriaan.com";
-      $order->billingAddress->phone = "+31208202070";
-      $order->update();
+      $orderId = "ord_kEn1PlbGa";
+      $order = $mollie->orders->update($orderId, [
+        "billingAddress" => [
+          "organizationName" => "Mollie B.V.",
+          "streetAndNumber" => "Keizersgracht 126",
+          "city" => "Amsterdam",
+          "region" => "Noord-Holland",
+          "postalCode" => "1234AB",
+          "country" => "NL",
+          "title" => "Dhr",
+          "givenName" => "Piet",
+          "familyName" => "Mondriaan",
+          "email" => "piet@mondriaan.com",
+          "phone" => "+31208202070",
+        ],
+      ]);
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/payments-api/update-payment.rst
+++ b/source/reference/v2/payments-api/update-payment.rst
@@ -163,14 +163,14 @@ Example
       <?php
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
-      $payment = $mollie->payments->get("tr_7UhSN1zuXS");
 
-      $payment->description = "Order #98765";
-      $payment->redirectUrl = "https://example.org/webshop/order/98765/";
-      $payment->webhookUrl = "https://example.org/webshop/payments/webhook/";
-      $payment->metadata = ["order_id" => "98765"];
-
-      $payment = $payment->update();
+      $paymentId = "tr_7UhSN1zuXS";
+      $mollie->payments->update($paymentId, [
+        "description" => "Order #98765",
+        "redirectUrl" => "https://example.org/webshop/order/98765/",
+        "webhookUrl" => "https://example.org/webshop/payments/webhook/",
+        "metadata" => ["order_id" => "98765"],
+      ]);
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/profiles-api/update-profile.rst
+++ b/source/reference/v2/profiles-api/update-profile.rst
@@ -131,14 +131,15 @@ Example
       <?php
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setAccessToken("access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ");
-      $profile = $mollie->profiles->get("pfl_v9hTwCvYqw");
 
-      $profile->name = "My website name - Update 1";
-      $profile->website = "https://www.mywebsite2.com";
-      $profile->email = "info@mywebsite2.com";
-      $profile->phone = "+31208202070";
-      $profile->businessCategory = "OTHER_MERCHANDISE";
-      $updatedProfile = $profile->update();
+      $profileId = "pfl_v9hTwCvYqw";
+      $mollie->profiles->update($profileId, [
+        "name" => "My website name - Update 1",
+        "website" => "https://www.mywebsite2.com",
+        "email" => "info@mywebsite2.com",
+        "phone" => "+31208202070",
+        "businessCategory" => "OTHER_MERCHANDISE",
+      ]);
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/shipments-api/update-shipment.rst
+++ b/source/reference/v2/shipments-api/update-shipment.rst
@@ -88,15 +88,15 @@ Example
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
 
-      $order = $mollie->orders->get('ord_kEn1PlbGa');
-      $shipment = $order->getShipment("shp_3wmsgCJN4U");
-
-      $shipment->tracking = [
-            'carrier' => 'PostNL',
-            'code' => '3SKABA000000000',
-            'url' => 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C',
-      ];
-      $shipment = $shipment->update();
+      $orderId = "ord_kEn1PlbGa";
+      $shipmentId = "shp_3wmsgCJN4U";
+      $mollie->shipments->update($orderId, $shipmentId, [
+        "tracking" => [
+          "carrier" => "PostNL",
+          "code" => "3SKABA000000000",
+          "url" => "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1015CW&D=NL&T=C",
+        ],
+      ]);
 
    .. code-block:: python
       :linenos:

--- a/source/reference/v2/subscriptions-api/update-subscription.rst
+++ b/source/reference/v2/subscriptions-api/update-subscription.rst
@@ -136,18 +136,19 @@ Example
       <?php
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setApiKey("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM");
-      $customer = $mollie->customers->get("cst_8wmqcHMN4U");
 
-      $subscription = $customer->getSubscription("sub_8EjeBVgtEn");
-      $subscription->amount = (object) [
-            "currency" => "EUR",
-            "value" => "10.00",
-      ];
-      $subscription->times = 42;
-      $subscription->startDate = "2018-12-12";
-      $subscription->description = "Mollie recurring subscription";
-      $subscription->webhookUrl = "https://example.org/webhook";
-      $updatedSubscription = $subscription->update();
+      $customerId = "cst_8wmqcHMN4U";
+      $subscriptionId = "sub_8EjeBVgtEn";
+      $mollie->subscriptions->update($customerId, $subscriptionId, [
+        "amount" => [
+          "currency" => "EUR",
+          "value" => "10.00",
+        ],
+        "times" => 42,
+        "startDate" => "2018-12-12",
+        "description" => "Mollie recurring subscription",
+        "webhookUrl" => "https://example.org/webhook",
+      ]);
 
    .. code-block:: python
       :linenos:


### PR DESCRIPTION
The old recommended approach was to do update calls like this with mollie-api-php:

```php
$payment = $mollie->payments->get($id);
$payment->webhookUrl = "https://updated.com";
$payment->update();
```

This way however, all updatable fields are sent over to Mollie's API on each update request. I have encountered multiple tickets over time from integrators asking for more granularity and control here. So a while ago I've added methods to directly make the update call and pass in all id's and payload directly.

```php
$payment = $mollie->payments->update($id, [
  "webhookUrl" => "https://updated.com",
]);
```

While I feel the old examples look nicer, the way described below has been now proven to result in a better developer experience. So I've matched the examples accordingly. :)