### PR TITLE
POS-163 - Add terminal related OAuth scopes

### DIFF
--- a/source/connect/permissions.rst
+++ b/source/connect/permissions.rst
@@ -112,3 +112,11 @@ Permissions can be requested by redirecting the resource owner to the
    * - | ``balances.read``
        | Balances API
      - View the merchant's balances information.
+
+   * - | ``terminals.read``
+       | Terminals API
+     - View the merchant's Point of Sale terminals.
+
+   * - | ``terminals.write``
+       | Terminals API
+     - Manage the merchant's Point of Sale terminals.


### PR DESCRIPTION
As part of POS-163, we're adding the functionality of being able to create access tokens with terminal related OAuth scopes.

This PR adds the documentation for these scopes.