### PR TITLE
Fix sphinx does not work when Python's user base path is not part of $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@
 
 # Minimal makefile for Sphinx documentation
 #
+PYTHON_USER_BASE_PATH = $(shell python3 -m site --user-base)/bin
 
 # You can set these variables from the command line. When editing extensions, it is
 # recommended to use the "-E" flag to force a rebuild every time you run 'Make', as
 # it is not guaranteed it will rebuild when no '.rst' files have changed.
-DEV_PYTHON        = MOLLIE_DOCS_URL='http://127.0.0.1:8000' MOLLIE_FILE_SUFFIX='.html' python3
+DEV_PYTHON        = PATH=${PYTHON_USER_BASE_PATH}:$$PATH MOLLIE_DOCS_URL='http://127.0.0.1:8000' MOLLIE_FILE_SUFFIX='.html' python3
 PROD_PYTHON       = MOLLIE_DOCS_URL='https://docs.mollie.com' MOLLIE_FILE_SUFFIX='' python3
 DEV_SPHINX_OPTS   = -W
 PROD_SPHINX_OPTS  = -W -n
@@ -20,6 +21,7 @@ clean:
 	rm -rf build/
 
 node_modules/.bin/parcel: package-lock.json
+	# this requires python 2 for a successfull install
 	npm install --no-optional --no-audit
 
 source/_static/style.css: $(wildcard source/theme/styles/**/*) node_modules/.bin/parcel

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^6.8.0",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.4",
-    "node-sass": "^4.14.1",
     "parcel-bundler": "^1.12.4",
     "prettier": "^2.2.1",
     "sass": "^1.32.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-sphinx==1.8.5
+sphinx==1.8.6
 jinja2==3.0.0
-docutils==0.17.1
 sphinx-autobuild==0.7.1
 cloud-sptheme==1.10.0


### PR DESCRIPTION
Various `make` commands such as `make html-reload` did not work on my local machine.

Turned out that the user path where the dependencies are installed by `pip` was not in my `$PATH`. 

A little `Makefile` magic takes care of this. 

In addition, @ZsoltMollie told me the `"node-sass` module isn't needed. One of its dependencies requires python 2 which makes everything more complicated, so good riddance. 