### PR TITLE
Pin the 'urllib3' package version, to prevent the 'make html' command from breaking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==1.8.6
 jinja2==3.0.0
+urllib3==1.*
 sphinx-autobuild==0.7.1
 cloud-sptheme==1.10.0


### PR DESCRIPTION
Pin the 'urllib3' package version, as version 2 and up is not compatible with the version of sphinx we use.

The 'make html' command is currently broken for new installations, as version 2 of 'urllib3' will be installed as part of 'make install'. That version is not compatible with our (very old!) version of sphinx that we pin to in our 'requirements.txt' file.

This is a quick fix to ensure new users of this repository can build the documentation locally. Existing users are not affected, because at the time they ran 'make install', version 2 of 'urllib3' was not released yet.