### PR TITLE
Made canceledAt in the get subscription endpoint optional

### DIFF
--- a/source/reference/v2/subscriptions-api/get-subscription.rst
+++ b/source/reference/v2/subscriptions-api/get-subscription.rst
@@ -132,6 +132,7 @@ Response
 
 .. parameter:: canceledAt
    :type: datetime
+   :condition: optional
 
    The subscription's date and time of cancellation, in `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ format.
    This parameter is omitted if the payment is not canceled (yet).


### PR DESCRIPTION
The `canceledAt` parameter is optional according to the description for it:
 > This parameter is omitted if the payment is not canceled (yet).

([Thanks](//github.com/mollie/mollie-api-node/pull/317) to @janpaepke)