### PR TITLE
ENG-597 - Disallow over-refunding by default

### DIFF
--- a/source/payments/refunds.rst
+++ b/source/payments/refunds.rst
@@ -52,14 +52,10 @@ is available again. We will automatically process the refund once your balance i
 Additionally, you can also manually top up your balance via the `Administration page
 <https://www.mollie.com/dashboard/administration>`_ in the Mollie Dashboard.
 
-Partial refunds and over-refunding
+Partial refunds
 ----------------------------------
 Partial refunds are fully supported. You can create multiple partial refunds if needed. Note that we will prevent
 duplicate refunds in a short time frame.
-
-Additionally, most payment methods (notable exceptions being credit card and PayPal) support over refunding, where you
-can refund an additional €25.00 more than the original payment's amount. You can use this for crediting shipping costs
-for returns to your customer, for example.
 
 Possible errors
 ---------------

--- a/source/reference/v1/refunds-api/create-refund.rst
+++ b/source/reference/v1/refunds-api/create-refund.rst
@@ -23,8 +23,7 @@ Most payment methods support :doc:`refunds </payments/refunds>`. This means you 
 to your customer. The amount of the refund will be withheld from your next settlement.
 
 By supplying the optional ``amount`` parameter, you can issue a partial refund where your customer is only refunded part
-of the total payment. It is also possible to refund up to €25.00 more than the original transaction amount, for example
-to credit costs for return shipping.
+of the total payment.
 
 Refunds support descriptions, which we will show in the Dashboard, your exports and pass to your customer if possible.
 
@@ -36,8 +35,7 @@ Replace ``id`` in the endpoint URL by the payment's ID, for example ``tr_7UhSN1z
    :type: decimal
    :condition: optional
 
-   The amount to refund. When ommitted, the full amount is refunded. Can be up to €25.00 more than the original
-   transaction amount.
+   The amount to refund. When ommitted, the full amount is refunded.
 
 .. parameter:: description
    :type: string


### PR DESCRIPTION
Mollie no longer allows over-refunding by default. This is only available when configured on the org-level by a Mollie employee, but since this is an edge-case now.