### PR TITLE
Change wording on Client Links API status

### DIFF
--- a/source/reference/v2/client-links-api/create-client-link.rst
+++ b/source/reference/v2/client-links-api/create-client-link.rst
@@ -4,8 +4,7 @@ Create client link
    :version: 2
    :beta: true
 
-.. note:: The Client Links API is currently in closed beta. Contact our partner management team if you are interested in
-   testing this functionality with us.
+.. note:: The Client Links API is in closed beta and only available to selected partners. Please contact your partner manager / partners@mollie.com if you want to implement this.
 
 .. endpoint::
    :method: POST

--- a/source/reference/v2/client-links-api/overview.rst
+++ b/source/reference/v2/client-links-api/overview.rst
@@ -3,8 +3,7 @@ Client Links API
 .. customize-document-title::
    :beta: true
 
-.. note:: The Client Links API is currently in closed beta. Contact our partner management team if you are interested in
-   testing this functionality with us.
+.. note:: The Client Links API is in closed beta and only available to selected partners. Please contact your partner manager / partners@mollie.com if you want to implement this.
 
 The Client Links API is part of our partnerships toolkit. If you are a registered Mollie partner, you can use the Client Links API
 to create new organizations for your customers. The organizations you create are automatically connected to your partner account.


### PR DESCRIPTION
This changes the wording on the Client Links API, clarifying how partners can implement the new API.