### PR TITLE
POS-414 Removing deactivatedAt field from Terminals API endpoints

### DIFF
--- a/source/reference/v2/terminals-api/get-terminal.rst
+++ b/source/reference/v2/terminals-api/get-terminal.rst
@@ -99,13 +99,6 @@ Response
 
    The date and time the terminal was last updated, in `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ format.
 
-.. parameter:: deactivatedAt
-   :type: datetime
-   :condition: optional
-
-   The date and time the terminal was deactivated, in `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ format. This
-   parameter is omitted if the terminal is not deactivated yet.
-
 .. parameter:: _links
    :type: object
 
@@ -188,8 +181,7 @@ Response
        "currency": "EUR",
        "description": "Terminal #12345",
        "createdAt": "2022-02-12T11:58:35.0Z",
-       "updatedAt": "2022-11-15T13:32:11+00:00",
-       "deactivatedAt": "2022-02-12T12:13:35.0Z",
+       "updatedAt": "2022-11-15T13:32:11.0Z",
        "_links": {
            "self": {
                "href": "https://api.mollie.com/v2/terminals/term_7MgL4wea46qkRcoTZjWEH",

--- a/source/reference/v2/terminals-api/list-terminals.rst
+++ b/source/reference/v2/terminals-api/list-terminals.rst
@@ -188,8 +188,7 @@ Response
                    "currency": "EUR",
                    "description": "Terminal #12345",
                    "createdAt": "2022-02-12T11:58:35.0Z",
-                   "updatedAt": "2022-11-15T13:32:11+00:00",
-                   "deactivatedAt": "2022-02-12T12:13:35.0Z",
+                   "updatedAt": "2022-11-15T13:32:11.0Z",
                    "_links": {
                        "self": {
                            "href": "https://api.mollie.com/v2/terminals/term_7MgL4wea46qkRcoTZjWEH",


### PR DESCRIPTION
Based on https://mollie.atlassian.net/browse/API-32 and https://mollie.atlassian.net/browse/POS-414 we need to remove the `deactivatedAt` field from the following endpoints:

- v2/terminals/*id*
- v2/terminals