### PR TITLE
Add note regarding payment scheme during testing

### DIFF
--- a/source/overview/testing.rst
+++ b/source/overview/testing.rst
@@ -91,3 +91,5 @@ card numbers below to test different card brands.
    +------------------+-------------------------+-------------+------+
    | VISA             | ``4543 4740 0224 9996`` | Any         | Any  |
    +------------------+-------------------------+-------------+------+
+
+**Note:** The card brand above allows you to test the dynamic display of the card logo in the card number field. For the time being, when processed the test payment will default to Mastercard always.


### PR DESCRIPTION
When using Mollie Components to test card payments, we can use the test card numbers to test different card brands. But in test mode, the payment scheme is saved as a default one (Mastercard). In this PR I've added a note to explain this situation.