### PR TITLE
Fix client link API examples

### DIFF
--- a/source/reference/v2/client-links-api/create-client-link.rst
+++ b/source/reference/v2/client-links-api/create-client-link.rst
@@ -154,7 +154,7 @@ Example
 .. code-block:: none
    :linenos:
 
-   https://my.mollie.com/dashboard/client-link/finalize/csr_vZCnNQsV2UtfXxYifWKWH?client_id=app_j9Pakf56Ajta6Y65AkdTtAv&state=decafbad&scope=onboarding.read+organizations.read+payments.write+payments.read+profiles.write
+   https://my.mollie.com/dashboard/client-link/cl_vZCnNQsV2UtfXxYifWKWH?client_id=app_j9Pakf56Ajta6Y65AkdTtAv&state=decafbad&scope=onboarding.read+organizations.read+payments.write+payments.read+profiles.write
 
 In case of an invalid value, your customer will be redirected to the redirect URI set for your OAuth application with
 the ``error`` and ``error_description`` query parameters added.
@@ -195,11 +195,11 @@ Response
    Content-Type: application/hal+json; charset=utf-8
 
    {
-       "id": "csr_vZCnNQsV2UtfXxYifWKWH",
+       "id": "cl_vZCnNQsV2UtfXxYifWKWH",
        "resource": "client-link",
        "_links": {
            "clientLink": {
-               "href": "https://my.mollie.com/dashboard/client-link/csr_vZCnNQsV2UtfXxYifWKWH",
+               "href": "https://my.mollie.com/dashboard/client-link/cl_vZCnNQsV2UtfXxYifWKWH",
                "type": "text/html"
            },
            "documentation": {


### PR DESCRIPTION
This PR fixes a few small issues with the Client Link API examples, like updating the client link token prefixes and updating a URL returned from the API.