### PR TITLE
Fix PHP code example for Get Primary Balance

### DIFF
--- a/source/reference/v2/balances-api/get-primary-balance.rst
+++ b/source/reference/v2/balances-api/get-primary-balance.rst
@@ -59,7 +59,7 @@ Request
       <?php
       $mollie = new \Mollie\Api\MollieApiClient();
       $mollie->setAccessToken("access_vR6naacwfSpfaT5CUwNTdV5KsVPJTNjURkgBPdvW");
-      $balance = $mollie->balances->getPrimary();
+      $balance = $mollie->balances->primary();
 
 Response
 ^^^^^^^^


### PR DESCRIPTION
According to https://github.com/mollie/mollie-api-php/blob/d6bcaf8329e0e32a690f0c9027d9165d9608be99/src/Endpoints/BalanceEndpoint.php#L54-L66 the primary balance is retrieved calling `primary()`.

Thx René for pointing this out!