### PR TITLE
Add new fields to the Profiles API

### DIFF
--- a/source/reference/v2/profiles-api/create-profile.rst
+++ b/source/reference/v2/profiles-api/create-profile.rst
@@ -44,6 +44,18 @@ Parameters
    The phone number associated with the profile's trade name or brand. Must be in the
    `E.164 <https://en.wikipedia.org/wiki/E.164>`_ format. For example ``+31208202070``.
 
+.. parameter:: description
+   :type: string
+   :condition: optional
+
+   The products or services that the profile's website offers.
+
+.. parameter:: countriesOfActivity
+   :type: array
+   :condition: optional
+
+   The list of countries where you expect that the majority of the profile's customers will live, in `ISO 3166-1 alpha-2 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ format.
+
 .. parameter:: businessCategory
    :type: string
    :condition: optional

--- a/source/reference/v2/profiles-api/get-profile.rst
+++ b/source/reference/v2/profiles-api/get-profile.rst
@@ -62,6 +62,16 @@ Response
 
    The phone number associated with the profile's trade name or brand.
 
+.. parameter:: description
+   :type: string
+
+   The products or services that the profile's website offers.
+
+.. parameter:: countriesOfActivity
+   :type: array
+
+   The list of countries where you expect that the majority of the profile's customers will live, in `ISO 3166-1 alpha-2 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ format.
+
 .. parameter:: businessCategory
    :type: string
 

--- a/source/reference/v2/profiles-api/update-profile.rst
+++ b/source/reference/v2/profiles-api/update-profile.rst
@@ -46,6 +46,18 @@ Even though all parameters are optional, at least one of them needs to be provid
    The new phone number associated with the profile's trade name or brand. Must be in the
    `E.164 <https://en.wikipedia.org/wiki/E.164>`_ format. For example ``+31208202070``.
 
+.. parameter:: description
+   :type: string
+   :condition: optional
+
+   The products or services that the profile's website offers.
+
+.. parameter:: countriesOfActivity
+   :type: array
+   :condition: optional
+
+   The list of countries where you expect that the majority of the profile's customers will live, in `ISO 3166-1 alpha-2 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ format.
+
 .. parameter:: businessCategory
    :type: string
    :condition: optional


### PR DESCRIPTION
This MR adds the newly introduced `description` and `countriesOfActivity` fields to the Profiles API. These fields are optional for create and update calls.