### PR TITLE
Revert "Update methods to include twint and blik"

### DIFF
--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -9,7 +9,6 @@ changes are documented here.
 January 2024
 =============
 - Added support for the `description` and `countriesOfActivity` fields on the Profiles API
-- Twint and Blik are generally available.
 
 December 2023
 =============

--- a/source/reference/v2/orders-api/create-order-payment.rst
+++ b/source/reference/v2/orders-api/create-order-payment.rst
@@ -37,9 +37,9 @@ Replace ``orderId`` in the endpoint URL by the order's ID, for example ``ord_8wm
    will only show the methods specified in the array. For example, you can use this functionality to only show payment
    methods from a specific country to your customer ``["bancontact", "belfius"]``.
 
-   Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``billie`` ``blik`` ``creditcard`` ``directdebit`` ``eps``
+   Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``billie`` ``creditcard`` ``directdebit`` ``eps``
    ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc``  ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``paypal``
-   ``paysafecard`` ``przelewy24`` ``sofort`` ``twint``
+   ``paysafecard`` ``przelewy24`` ``sofort``
 
 .. parameter:: customerId
    :type: string

--- a/source/reference/v2/orders-api/create-order.rst
+++ b/source/reference/v2/orders-api/create-order.rst
@@ -438,9 +438,9 @@ Parameters
    will only show the methods specified in the array. For example, you can use this functionality to only show payment
    methods from a specific country to your customer ``['bancontact', 'belfius']``.
 
-   Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``billie`` ``blik`` ``creditcard`` ``directdebit`` ``eps``
+   Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``billie`` ``creditcard`` ``directdebit`` ``eps``
    ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc`` ``klarna`` ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``mybank``
-   ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort`` ``twint`` ``voucher``
+   ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort`` ``voucher``
 
 .. parameter:: payment
    :type: object

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -131,8 +131,8 @@ Parameters
    will only show the methods specified in the array. For example, you can use this functionality to only show payment
    methods from a specific country to your customer ``['bancontact', 'belfius']``.
 
-   Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``blik`` ``creditcard`` ``directdebit`` ``eps``
-   ``giftcard`` ``giropay`` ``ideal`` ``kbc`` ``mybank``  ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort`` ``twint``
+   Possible values: ``applepay`` ``bancontact`` ``banktransfer`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
+   ``giftcard`` ``giropay`` ``ideal`` ``kbc`` ``mybank``  ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort``
 
    .. note:: If you are looking to create payments with the Klarna Pay now, Klarna Pay later, Klarna Slice it, in3 or
       voucher payment methods, use :doc:`/reference/v2/orders-api/create-order` instead.

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -288,9 +288,9 @@ Response
 
    If the payment is only partially paid with a gift card, the method remains ``giftcard``.
 
-   Possible values: ``null`` ``bancontact`` ``banktransfer`` ``belfius`` ``billie`` ``blik`` ``creditcard`` ``directdebit``
-   ``eps`` ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc`` ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit``
-   ``mybank`` ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort`` ``twint``
+   Possible values: ``null`` ``bancontact`` ``banktransfer`` ``billie`` ``belfius`` ``creditcard`` ``directdebit`` ``eps``
+   ``giftcard`` ``giropay`` ``ideal`` ``in3`` ``kbc`` ``klarnapaylater`` ``klarnapaynow`` ``klarnasliceit`` ``mybank``
+   ``paypal`` ``paysafecard`` ``przelewy24`` ``sofort``
 
 .. parameter:: restrictPaymentMethodsToCountry
    :type: string


### PR DESCRIPTION
Reverts mollie/api-documentation#981