### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/source/mobile-apps/getting-started-payments.rst
+++ b/source/mobile-apps/getting-started-payments.rst
@@ -8,7 +8,7 @@ show you a basic example of integrating Mollie Payments in your iOS or Android a
 
 Keep the guidelines of the platform you are developing on in mind
 -----------------------------------------------------------------
-Every platform has it's own guidelines for accepting of rejecting apps in the App Store or Marketplace. See
+Every platform has its own guidelines for accepting or rejecting apps in the App Store or Marketplace. See
 :ref:`app-store-r-r` for an in depth review.
 
 Step 1: Create a Payment-creation script on your server

--- a/source/orders/overview.rst
+++ b/source/orders/overview.rst
@@ -36,7 +36,7 @@ How does the Orders API work?
 #. The :ref:`Create order endpoint response <create-order-response>` contains the ``_links.checkout`` property. This is
    a link where you should redirect your customer to for checking out.
 
-#. If the checkout is successful, the order will change it's state to ``authorized`` or ``paid``, depending on the
+#. If the checkout is successful, the order will change its state to ``authorized`` or ``paid``, depending on the
    payment method used by your customer.
 
    We will use webhooks to inform your back office of the order state change.


### PR DESCRIPTION
- Fix two occurrences where `it's` (it is) was used instead of the possessive its;
- Fix one occurrence of the Dutch `of` instead of `or`.