### PR TITLE
Fix Mollie website partners link in all docs

### DIFF
--- a/source/integration-partners/getting-started.rst
+++ b/source/integration-partners/getting-started.rst
@@ -11,7 +11,7 @@ Mollie <3 developers. We have a large community of partners and developers build
 our community.
 
 If you are integrating the Mollie API into a plugin, module or SaaS platform, we would love to work with you! Be sure to
-reach out to our `technical partner team <https://www.mollie.com/partners>`_ and we will make sure you get all the help
+reach out to our `technical partner team <https://www.mollie.com/nl/partner-program/saas-ecommerce#form>`_ and we will make sure you get all the help
 you need.
 
 Partnered developers are also invited to join our Slack community, where other members and Mollie developers will be

--- a/source/integration-partners/getting-started.rst
+++ b/source/integration-partners/getting-started.rst
@@ -11,7 +11,7 @@ Mollie <3 developers. We have a large community of partners and developers build
 our community.
 
 If you are integrating the Mollie API into a plugin, module or SaaS platform, we would love to work with you! Be sure to
-reach out to our `technical partner team <https://www.mollie.com/nl/partner-program/saas-ecommerce#form>`_ and we will make sure you get all the help
+reach out to our `technical partner team <https://www.mollie.com/partner-program/saas-ecommerce#form>`_ and we will make sure you get all the help
 you need.
 
 Partnered developers are also invited to join our Slack community, where other members and Mollie developers will be

--- a/source/reference/v2/client-links-api/overview.rst
+++ b/source/reference/v2/client-links-api/overview.rst
@@ -9,7 +9,7 @@ Client Links API
 The Client Links API is part of our partnerships toolkit. If you are a registered Mollie partner, you can use the Client Links API
 to create new organizations for your customers. The organizations you create are automatically connected to your partner account.
 
-For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/partners>`_.
+For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/nl/partner-program/saas-ecommerce#form>`_.
 
 Endpoints
 ---------

--- a/source/reference/v2/client-links-api/overview.rst
+++ b/source/reference/v2/client-links-api/overview.rst
@@ -9,7 +9,7 @@ Client Links API
 The Client Links API is part of our partnerships toolkit. If you are a registered Mollie partner, you can use the Client Links API
 to create new organizations for your customers. The organizations you create are automatically connected to your partner account.
 
-For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/nl/partner-program/saas-ecommerce#form>`_.
+For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/partner-program/saas-ecommerce#form>`_.
 
 Endpoints
 ---------

--- a/source/reference/v2/clients-api/overview.rst
+++ b/source/reference/v2/clients-api/overview.rst
@@ -4,7 +4,7 @@ The Clients API is part of our partnerships toolkit. If you are a registered Mol
 to create new organizations for your customers, or retrieve a list of Mollie organizations connected to your partner
 account.
 
-For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/nl/partner-program/saas-ecommerce#form>`_.
+For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/partner-program/saas-ecommerce#form>`_.
 
 Endpoints
 ---------

--- a/source/reference/v2/clients-api/overview.rst
+++ b/source/reference/v2/clients-api/overview.rst
@@ -4,7 +4,7 @@ The Clients API is part of our partnerships toolkit. If you are a registered Mol
 to create new organizations for your customers, or retrieve a list of Mollie organizations connected to your partner
 account.
 
-For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/partners>`_.
+For more information on our partnership program, visit `mollie.com/partners <https://www.mollie.com/nl/partner-program/saas-ecommerce#form>`_.
 
 Endpoints
 ---------


### PR DESCRIPTION
Changed all occurances of https://www.mollie.com/partners to https://www.mollie.com/nl/partner-program/saas-ecommerce#form