### PR TITLE
PC-1560 Add lines parameter for Payments API

### DIFF
--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -9,6 +9,7 @@ changes are documented here.
 April 2024
 ==========
 - :doc:`Placing a hold on a payment </payments/place-a-hold-for-a-payment>` is now general available.
+- Added support for `lines` parameter on the Payments API.
 
 April 2024
 ==========

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -8,8 +8,7 @@ changes are documented here.
 
 May 2024
 ========
-- Added `lines` parameter on the :doc:`/reference/v2/payments-api`. Lines will be displayed on the 
-:doc:`Hosted Checkout </payments/hosted-checkout>`.
+- Added ``lines`` parameter on the :doc:`/reference/v2/payments-api`.
 
 April 2024
 ==========
@@ -21,12 +20,12 @@ April 2024
 
 March 2024
 ==========
-- Added support for `sort` parameter on the List Payments and List Orders endpoints.
+- Added support for ``sort`` parameter on the List Payments and List Orders endpoints.
 - Edenred vouchers and Twint are generally available.
 
 January 2024
 =============
-- Added support for the `description` and `countriesOfActivity` fields on the Profiles API
+- Added support for the ``description`` and ``countriesOfActivity`` fields on the Profiles API
 
 December 2023
 =============

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -8,7 +8,7 @@ changes are documented here.
 
 April 2024
 ==========
-- Added support for `lines` parameter on the Payments API.
+- Added support for `lines` parameter on the :doc:`/reference/v2/payments-api`.
 
 April 2024
 ==========

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -8,6 +8,10 @@ changes are documented here.
 
 April 2024
 ==========
+- Added support for `lines` parameter on the Payments API.
+
+April 2024
+==========
 - :doc:`Placing a hold on a payment </payments/place-a-hold-for-a-payment>` is now general available.
 
 March 2024

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -10,6 +10,7 @@ April 2024
 ==========
 - :doc:`Placing a hold on a payment </payments/place-a-hold-for-a-payment>` is now general available.
 - Added support for `lines` parameter on the Payments API.
+- Added support for `lines` parameter on the :doc:`/reference/v2/payments-api`.
 
 April 2024
 ==========

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -6,11 +6,13 @@ Changelog
 Occasionally, we will add new resources, new fields, or new possible values to existing fields to the v2 Mollie API. All
 changes are documented here.
 
+May 2024
+========
+- Added support for `lines` parameter on the :doc:`/reference/v2/payments-api`.
+
 April 2024
 ==========
 - :doc:`Placing a hold on a payment </payments/place-a-hold-for-a-payment>` is now general available.
-- Added support for `lines` parameter on the Payments API.
-- Added support for `lines` parameter on the :doc:`/reference/v2/payments-api`.
 
 April 2024
 ==========

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -8,11 +8,10 @@ changes are documented here.
 
 May 2024
 ========
-- Added ``lines`` parameter on the :doc:`/reference/v2/payments-api`.
+We are introducing a new beta parameter to the Payments API that allows adding line item information.
 
-April 2024
-==========
-- :doc:`Placing a hold on a payment </payments/place-a-hold-for-a-payment>` is now general available.
+- Added ``lines`` parameter on the :doc:`/reference/v2/payments-api/create-payment` endpoint.
+- Added ``lines`` parameter on the :doc:`/reference/v2/payments-api/get-payment` endpoint.
 
 April 2024
 ==========

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -8,7 +8,8 @@ changes are documented here.
 
 May 2024
 ========
-- Added support for `lines` parameter on the :doc:`/reference/v2/payments-api`.
+- Added `lines` parameter on the :doc:`/reference/v2/payments-api`. Lines will be displayed on the 
+:doc:`Hosted Checkout </payments/hosted-checkout>`.
 
 April 2024
 ==========

--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -8,7 +8,7 @@ changes are documented here.
 
 April 2024
 ==========
-- Added support for `lines` parameter on the :doc:`/reference/v2/payments-api`.
+- :doc:`Placing a hold on a payment </payments/place-a-hold-for-a-payment>` is now general available.
 
 April 2024
 ==========

--- a/source/extensions/mollie/parameter_directive.py
+++ b/source/extensions/mollie/parameter_directive.py
@@ -11,6 +11,7 @@ class ParameterDirective(Directive):
     option_spec = {
         "type": directives.unchanged_required,
         "condition": directives.unchanged,
+        "beta": utilities.validate_bool,
         "collapse": utilities.validate_bool,
         "collapse-children": utilities.validate_bool
     }
@@ -26,6 +27,9 @@ class ParameterDirective(Directive):
 
         if "condition" in self.options:
             self.add_condition_node(name_container, self.options["condition"])
+
+        if "beta" in self.options:
+            self.add_beta_node(name_container)
 
         collapse = "collapse" in self.options and self.options["collapse"] is True
 
@@ -70,6 +74,12 @@ class ParameterDirective(Directive):
             condition_node["classes"] += ["parameter__condition--conditional"]
 
         container += [condition_node]
+
+    def add_beta_node(self, container):
+        data_type_node = nodes.inline(text="beta")
+        data_type_node["classes"] = ["parameter__beta"]
+
+        container += [data_type_node]
 
     def add_collapse_toggle_node(self, container):
         collapse_button_node = nodes.raw(

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -111,7 +111,9 @@ Parameters
 
    .. _order-lines-details:
 
-   The lines for the payment. Each line contains details such as a description of the item ordered, its price et cetera.
+   The lines for the payment. These will be displayed on the :doc:`hosted-checkout`.
+
+   Each line contains details such as a description of the item ordered, its price et cetera.
 
    All lines must have the same currency as the payment. You cannot mix currencies within a single payment.
 
@@ -123,20 +125,6 @@ Parameters
 
       Possible values: ``physical`` ``discount`` ``digital`` ``shipping_fee`` ``store_credit`` ``gift_card``
       ``surcharge``
-
-      For selling digitally delivered goods through PayPal, request PayPal to `enable this on your account
-      <https://developer.paypal.com/docs/classic/express-checkout/digital-goods/IntroducingExpressCheckoutDG/>`_.
-
-   .. parameter:: category
-      :type: string
-      :condition: optional
-
-      The category of product bought.
-
-      This parameter is optional. However, *one* of your order lines should contain it if you want to accept ``voucher``
-      payments.
-
-      Possible values: ``meal`` ``eco`` ``gift``
 
    .. parameter:: description
       :type: string

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -108,6 +108,7 @@ Parameters
 .. parameter:: lines
    :type: array
    :condition: optional
+   :beta: true
 
    .. _order-lines-details:
 

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -167,7 +167,7 @@ Parameters
 
       For example: ``{"currency":"EUR", "value":"89.00"}`` if the box of LEGO costs €89.00 each.
 
-      Can be negative in case of discounts, or zero in case of a free item.
+      Should be negative if ``type`` is ``discount``, ``store_credit`` or ``gift_card``, or zero in case of a free item.
 
       .. parameter:: currency
          :type: string
@@ -183,8 +183,8 @@ Parameters
       :type: amount object
       :condition: optional
 
-      Any :doc:`discounts applied </orders/handling-discounts>` to the line. For example, if you have a
-      two-for-one sale, you should pass the amount discounted as a positive amount.
+      Any discounts applied to the line. For example, if you have a two-for-one sale, you should pass the amount discounted 
+      as a positive amount.
 
       For example: ``{"currency":"EUR", "value":"10.00"}`` if you want to give a €10.00 discount on this line.
 
@@ -202,12 +202,12 @@ Parameters
       :type: amount object
       :condition: required
 
-      The total amount of the line, including VAT and discounts. Adding all ``totalAmount`` values together should
-      result in the same amount as the ``amount`` top level property.
+      The total amount of the line, including VAT and discounts. For example: ``{"currency":"EUR", "value":"168.00"}`` if the
+      total amount of this line is €168.00.
 
-      For example: ``{"currency":"EUR", "value":"168.00"}`` if the total amount of this line is €168.00.
-
-      The total amount should match the following formula: ``(unitPrice × quantity) - discountAmount``
+      Should match the following formula: ``(unitPrice × quantity) - discountAmount``. 
+      
+      Adding ``totalAmount`` values of all lines together should result in the same amount as the ``amount`` top level property.
 
       .. parameter:: currency
          :type: string

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -124,9 +124,6 @@ Parameters
       Possible values: ``physical`` ``discount`` ``digital`` ``shipping_fee`` ``store_credit`` ``gift_card``
       ``surcharge``
 
-      For information on the ``discount``, ``store_credit`` and ``gift_card`` types, see our guide on
-      :doc:`handling discounts </orders/handling-discounts>`.
-
       For selling digitally delivered goods through PayPal, request PayPal to `enable this on your account
       <https://developer.paypal.com/docs/classic/express-checkout/digital-goods/IntroducingExpressCheckoutDG/>`_.
 

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -168,11 +168,13 @@ Parameters
 
       .. parameter:: currency
          :type: string
+         :condition: required
 
          An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
 
       .. parameter:: value
          :type: string
+         :condition: required
 
          A string containing the exact amount in the given currency.
 
@@ -187,11 +189,13 @@ Parameters
 
       .. parameter:: currency
          :type: string
+         :condition: required
 
          An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
 
       .. parameter:: value
          :type: string
+         :condition: required
 
          A string containing the exact amount in the given currency.
 
@@ -208,24 +212,26 @@ Parameters
 
       .. parameter:: currency
          :type: string
+         :condition: required
 
          An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
 
       .. parameter:: value
          :type: string
+         :condition: required
 
          A string containing the exact amount in the given currency.
 
    .. parameter:: vatRate
       :type: string
-      :condition: required
+      :condition: optional
 
       The VAT rate applied to the line, for example ``"21.00"`` for 21%. The ``vatRate`` should be passed as a
       string and not as a float to ensure the correct number of decimals are passed.
 
    .. parameter:: vatAmount
       :type: amount object
-      :condition: required
+      :condition: optional
 
       The amount of value-added tax on the line. The ``totalAmount`` field includes VAT, so the ``vatAmount`` can be
       calculated with the formula ``totalAmount × (vatRate / (100 + vatRate))``.
@@ -238,11 +244,13 @@ Parameters
 
       .. parameter:: currency
          :type: string
+         :condition: required
 
          An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
 
       .. parameter:: value
          :type: string
+         :condition: required
 
          A string containing the exact amount in the given currency.
 

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -105,6 +105,168 @@ Parameters
    `ngrok <https://lornajane.net/posts/2015/test-incoming-webhooks-locally-with-ngrok>`_ to have the webhooks delivered
    to your local machine.
 
+.. parameter:: lines
+   :type: array
+   :condition: optional
+
+   .. _order-lines-details:
+
+   The lines for the payment. Each line contains details such as a description of the item ordered, its price et cetera.
+
+   All lines must have the same currency as the payment. You cannot mix currencies within a single payment.
+
+   .. parameter:: type
+      :type: string
+      :condition: optional
+
+      The type of product bought, for example, a physical or a digital product.
+
+      Possible values: ``physical`` ``discount`` ``digital`` ``shipping_fee`` ``store_credit`` ``gift_card``
+      ``surcharge``
+
+      For information on the ``discount``, ``store_credit`` and ``gift_card`` types, see our guide on
+      :doc:`handling discounts </orders/handling-discounts>`.
+
+      For selling digitally delivered goods through PayPal, request PayPal to `enable this on your account
+      <https://developer.paypal.com/docs/classic/express-checkout/digital-goods/IntroducingExpressCheckoutDG/>`_.
+
+   .. parameter:: category
+      :type: string
+      :condition: optional
+
+      The category of product bought.
+
+      This parameter is optional. However, *one* of your order lines should contain it if you want to accept ``voucher``
+      payments.
+
+      Possible values: ``meal`` ``eco`` ``gift``
+
+   .. parameter:: description
+      :type: string
+      :condition: required
+
+      A description of the line item, for example *LEGO 4440 Forest Police Station*.
+
+   .. parameter:: quantity
+      :type: int
+      :condition: required
+
+      The number of items in the line.
+
+   .. parameter:: quantityUnit
+      :type: string
+      :condition: optional
+
+      The unit for the quantity, for example *pcs*, *kg*, *cm*, etc.
+
+   .. parameter:: unitPrice
+      :type: amount object
+      :condition: required
+
+      The price of a single item including VAT.
+
+      For example: ``{"currency":"EUR", "value":"89.00"}`` if the box of LEGO costs €89.00 each.
+
+      Can be negative in case of discounts, or zero in case of a free item.
+
+      .. parameter:: currency
+         :type: string
+
+         An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
+
+      .. parameter:: value
+         :type: string
+
+         A string containing the exact amount in the given currency.
+
+   .. parameter:: discountAmount
+      :type: amount object
+      :condition: optional
+
+      Any :doc:`discounts applied </orders/handling-discounts>` to the line. For example, if you have a
+      two-for-one sale, you should pass the amount discounted as a positive amount.
+
+      For example: ``{"currency":"EUR", "value":"10.00"}`` if you want to give a €10.00 discount on this line.
+
+      .. parameter:: currency
+         :type: string
+
+         An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
+
+      .. parameter:: value
+         :type: string
+
+         A string containing the exact amount in the given currency.
+
+   .. parameter:: totalAmount
+      :type: amount object
+      :condition: required
+
+      The total amount of the line, including VAT and discounts. Adding all ``totalAmount`` values together should
+      result in the same amount as the ``amount`` top level property.
+
+      For example: ``{"currency":"EUR", "value":"168.00"}`` if the total amount of this line is €168.00.
+
+      The total amount should match the following formula: ``(unitPrice × quantity) - discountAmount``
+
+      .. parameter:: currency
+         :type: string
+
+         An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
+
+      .. parameter:: value
+         :type: string
+
+         A string containing the exact amount in the given currency.
+
+   .. parameter:: vatRate
+      :type: string
+      :condition: required
+
+      The VAT rate applied to the line, for example ``"21.00"`` for 21%. The ``vatRate`` should be passed as a
+      string and not as a float to ensure the correct number of decimals are passed.
+
+   .. parameter:: vatAmount
+      :type: amount object
+      :condition: required
+
+      The amount of value-added tax on the line. The ``totalAmount`` field includes VAT, so the ``vatAmount`` can be
+      calculated with the formula ``totalAmount × (vatRate / (100 + vatRate))``.
+
+      Any deviations from this will result in an error.
+
+      For example, for a ``totalAmount`` of SEK100.00 with a 25.00% VAT rate you would get a VAT amount of
+      ``100.00 × (25 / 125)`` = SEK20.00. The amount should be passed as an amount object, so:
+      ``{"currency":"SEK", "value":"20.00"}``.
+
+      .. parameter:: currency
+         :type: string
+
+         An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code.
+
+      .. parameter:: value
+         :type: string
+
+         A string containing the exact amount in the given currency.
+
+   .. parameter:: sku
+      :type: string
+      :condition: optional
+
+      The SKU, EAN, ISBN or UPC of the product sold. The maximum character length is 64.
+
+   .. parameter:: imageUrl
+      :type: string
+      :condition: optional
+
+      A link pointing to an image of the product sold.
+
+   .. parameter:: productUrl
+      :type: string
+      :condition: optional
+
+      A link pointing to the product page in your web shop of the product sold.
+
 .. parameter:: locale
    :type: string
    :condition: optional

--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -112,9 +112,7 @@ Parameters
 
    .. _order-lines-details:
 
-   The lines for the payment. These will be displayed on the :doc:`hosted-checkout`.
-
-   Each line contains details such as a description of the item ordered, its price et cetera.
+   The lines for the payment. Each line contains details such as a description of the item ordered, its price et cetera.
 
    All lines must have the same currency as the payment. You cannot mix currencies within a single payment.
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -265,6 +265,92 @@ Response
 
    The URL Mollie will call as soon an important status change takes place.
 
+.. parameter:: lines
+   :type: array
+   :condition: optional
+
+   An array of line objects. Each object will have the properties listed below.
+
+   .. parameter:: type
+      :type: string
+      :condition: optional
+
+      The type of product bought, for example, a physical or a digital product.
+
+      Possible values: ``physical`` ``discount`` ``digital`` ``shipping_fee`` ``store_credit`` ``gift_card``
+      ``surcharge``
+
+   .. parameter:: category
+      :type: string
+      :condition: optional
+
+      The category of product bought.
+
+      Possible values: ``meal`` ``eco`` ``gift``
+
+   .. parameter:: description
+      :type: string
+
+      A description of the line, for example *LEGO 4440 Forest Police Station*.
+
+   .. parameter:: quantity
+      :type: int
+
+      The number of items in the order line.
+
+   .. parameter:: quantityUnit
+      :type: string
+      :condition: optional
+
+      The unit of the quantity.
+
+   .. parameter:: unitPrice
+      :type: amount object
+
+      The price of a single item including VAT in the line.
+
+   .. parameter:: discountAmount
+      :type: amount object
+      :condition: optional
+
+      Any discounts applied to the line.
+
+   .. parameter:: totalAmount
+      :type: amount object
+
+      The total amount of the line, including VAT and discounts.
+
+   .. parameter:: vatRate
+      :type: string
+      :condition: optional
+
+      The VAT rate applied to the line, for example ``"21.00"`` for 21%. The ``vatRate`` is passed as a string and
+      not as a float to ensure the correct number of decimals are passed.
+
+   .. parameter:: vatAmount
+      :type: amount object
+      :condition: optional
+
+      The amount of value-added tax on the line.
+
+   .. parameter:: sku
+      :type: string
+      :condition: optional
+
+      The SKU, EAN, ISBN or UPC of the product sold.
+   
+   .. parameter:: imageUrl
+      :type: string
+      :condition: optional
+
+      A link pointing to an image of the product sold.
+
+   .. parameter:: productUrl
+      :type: string
+      :condition: optional
+
+      A link pointing to the product page in your web shop of the product sold.
+
 .. parameter:: locale
    :type: string
    :condition: optional

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -268,6 +268,7 @@ Response
 .. parameter:: lines
    :type: array
    :condition: optional
+   :beta: true
 
    An array of line objects. Each object will have the properties listed below.
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -280,14 +280,6 @@ Response
       Possible values: ``physical`` ``discount`` ``digital`` ``shipping_fee`` ``store_credit`` ``gift_card``
       ``surcharge``
 
-   .. parameter:: category
-      :type: string
-      :condition: optional
-
-      The category of product bought.
-
-      Possible values: ``meal`` ``eco`` ``gift``
-
    .. parameter:: description
       :type: string
 

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -271,6 +271,17 @@ Response
 
    An array of line objects. Each object will have the properties listed below.
 
+   .. parameter:: description
+      :type: string
+
+      A description of the line, for example *LEGO 4440 Forest Police Station*.
+
+   .. parameter:: sku
+      :type: string
+      :condition: optional
+
+      The SKU, EAN, ISBN or UPC of the product sold.
+
    .. parameter:: type
       :type: string
       :condition: optional
@@ -288,11 +299,6 @@ Response
 
       Possible values: ``meal`` ``eco`` ``gift``
 
-   .. parameter:: description
-      :type: string
-
-      A description of the line, for example *LEGO 4440 Forest Police Station*.
-
    .. parameter:: quantity
       :type: int
 
@@ -309,17 +315,6 @@ Response
 
       The price of a single item including VAT in the line.
 
-   .. parameter:: discountAmount
-      :type: amount object
-      :condition: optional
-
-      Any discounts applied to the line.
-
-   .. parameter:: totalAmount
-      :type: amount object
-
-      The total amount of the line, including VAT and discounts.
-
    .. parameter:: vatRate
       :type: string
       :condition: optional
@@ -333,11 +328,16 @@ Response
 
       The amount of value-added tax on the line.
 
-   .. parameter:: sku
-      :type: string
+   .. parameter:: discountAmount
+      :type: amount object
       :condition: optional
 
-      The SKU, EAN, ISBN or UPC of the product sold.
+      Any discounts applied to the line.
+
+   .. parameter:: totalAmount
+      :type: amount object
+
+      The total amount of the line, including VAT and discounts.
    
    .. parameter:: imageUrl
       :type: string

--- a/source/reference/v2/payments-api/get-payment.rst
+++ b/source/reference/v2/payments-api/get-payment.rst
@@ -271,17 +271,6 @@ Response
 
    An array of line objects. Each object will have the properties listed below.
 
-   .. parameter:: description
-      :type: string
-
-      A description of the line, for example *LEGO 4440 Forest Police Station*.
-
-   .. parameter:: sku
-      :type: string
-      :condition: optional
-
-      The SKU, EAN, ISBN or UPC of the product sold.
-
    .. parameter:: type
       :type: string
       :condition: optional
@@ -299,6 +288,11 @@ Response
 
       Possible values: ``meal`` ``eco`` ``gift``
 
+   .. parameter:: description
+      :type: string
+
+      A description of the line, for example *LEGO 4440 Forest Police Station*.
+
    .. parameter:: quantity
       :type: int
 
@@ -315,6 +309,17 @@ Response
 
       The price of a single item including VAT in the line.
 
+   .. parameter:: discountAmount
+      :type: amount object
+      :condition: optional
+
+      Any discounts applied to the line.
+
+   .. parameter:: totalAmount
+      :type: amount object
+
+      The total amount of the line, including VAT and discounts.
+
    .. parameter:: vatRate
       :type: string
       :condition: optional
@@ -328,16 +333,11 @@ Response
 
       The amount of value-added tax on the line.
 
-   .. parameter:: discountAmount
-      :type: amount object
+   .. parameter:: sku
+      :type: string
       :condition: optional
 
-      Any discounts applied to the line.
-
-   .. parameter:: totalAmount
-      :type: amount object
-
-      The total amount of the line, including VAT and discounts.
+      The SKU, EAN, ISBN or UPC of the product sold.
    
    .. parameter:: imageUrl
       :type: string

--- a/source/theme/styles/components/_api-name.scss
+++ b/source/theme/styles/components/_api-name.scss
@@ -10,9 +10,8 @@
   color: $brand-warning;
   padding: 5px;
   margin-left: 8px;
-  border: 1px solid $grey-medium;
+  border: 1px solid $brand-warning;
   border-radius: 4px;
-  background: #fcfcfc;
   font-size: 12px;
   font-weight: 700;
   vertical-align: top;

--- a/source/theme/styles/components/_parameters.scss
+++ b/source/theme/styles/components/_parameters.scss
@@ -131,6 +131,19 @@
   color: $orange-anzac;
 }
 
+.parameter__beta {
+  color: $brand-warning;
+  margin-left: 15px;
+  border: 1px solid $brand-warning;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 700;
+  vertical-align: top;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  line-height: 1rem;
+}
+
 .parameter__collapse-button {
   margin-left: auto;
   color: #666;


### PR DESCRIPTION
This PR introduces the `lines` parameter for the Payments API.

It also adds a beta option for parameters and includes a fix for the API beta flags for dark mode.