### PR TITLE
Create Payment Link DOC - Make amount object optional 

### DIFF
--- a/source/reference/v2/payment-links-api/create-payment-link.rst
+++ b/source/reference/v2/payment-links-api/create-payment-link.rst
@@ -28,22 +28,28 @@ Parameters
 
 .. parameter:: amount
    :type: amount object
-   :condition: required
+   :condition: optional
 
    The amount that you want to charge, e.g. ``{"currency":"EUR", "value":"1000.00"}`` if you would want to charge
    €1000.00.
 
+   Although its optional, a payment can not be made if no amount is provided.
+
    .. parameter:: currency
       :type: string
-      :condition: required
+      :condition: optional
 
       An `ISO 4217 <https://en.wikipedia.org/wiki/ISO_4217>`_ currency code. The
       :doc:`currencies supported </payments/multicurrency>` depend on the payment methods that are enabled on your
       account.
 
+      The currency is required when a value is provided.
+
    .. parameter:: value
       :type: string
-      :condition: required
+      :condition: optional
+
+      The value is required when an amount is provided.
 
       A string containing the exact amount you want to charge in the given currency. Make sure to send the right amount
       of decimals. Non-string values are not accepted.


### PR DESCRIPTION
The amount object should be optional in the Create Payment Link Documentation