### PR TITLE
POS-635: Terminals API is now generally available

### DIFF
--- a/source/changelog/v2/changelog.rst
+++ b/source/changelog/v2/changelog.rst
@@ -12,6 +12,7 @@ We are introducing a new beta parameter to the Payments API that allows adding l
 
 - Added ``lines`` parameter on the :doc:`/reference/v2/payments-api/create-payment` endpoint.
 - Added ``lines`` parameter on the :doc:`/reference/v2/payments-api/get-payment` endpoint.
+- Terminals API is now generally available
 
 April 2024
 ==========

--- a/source/point-of-sale/overview.rst
+++ b/source/point-of-sale/overview.rst
@@ -1,8 +1,7 @@
 Point-of-sale payments
 ======================
-.. note:: Point-of-sale is currently in beta. If you are interested in offering point-of-sale payments, please see
-   `this page <https://www.mollie.com/products/payments-terminal>`_ for more information on our product offering. Once
-   there, you can register your interest to be kept up-to-date.
+.. note:: If you are interested in offering point-of-sale payments, please see
+   `this page <https://www.mollie.com/products/payments-terminal>`_ for more information on our product offering.
 
 With Mollie you can accept in-person card payments next to your online payments, neatly unifying both your online and
 in-person presence. Mollie provides pre-certified card readers ('terminals') as well as fleet management tools via the

--- a/source/point-of-sale/testing.rst
+++ b/source/point-of-sale/testing.rst
@@ -1,8 +1,7 @@
 Test your point-of-sale integration
 ===================================
-.. note:: Point-of-sale is currently in beta. If you are interested in offering point-of-sale payments, please see
-   `this page <https://www.mollie.com/products/payments-terminal>`_ for more information on our product offering. Once
-   there, you can register your interest to be kept up-to-date.
+.. note:: If you are interested in offering point-of-sale payments, please see
+   `this page <https://www.mollie.com/products/payments-terminal>`_ for more information on our product offering.
 
 As explained in our guide on :doc:`Testing the Mollie API </overview/testing>`, you can use test mode to ensure your
 integration works as expected, before rolling it out to your customers.

--- a/source/reference/v2/terminals-api/get-terminal.rst
+++ b/source/reference/v2/terminals-api/get-terminal.rst
@@ -2,7 +2,6 @@ Get terminal
 ============
 .. api-name:: Terminals API
    :version: 2
-   :beta: true
 
 .. endpoint::
    :method: GET
@@ -15,7 +14,6 @@ Get terminal
 
 With this endpoint you can retrieve a single terminal object by its terminal ID. This terminal object symbolizes
 the physical device that you have received from us.
-This endpoint is not publicly available yet — please reach out to your account manager to sign up for early access.
 
 For more information on accepting point-of-sale payments, please refer to the
 :doc:`point-of-sale guide </point-of-sale/overview>`.

--- a/source/reference/v2/terminals-api/list-terminals.rst
+++ b/source/reference/v2/terminals-api/list-terminals.rst
@@ -2,7 +2,6 @@ List terminals
 ==============
 .. api-name:: Terminals API
    :version: 2
-   :beta: true
 
 .. endpoint::
    :method: GET

--- a/source/reference/v2/terminals-api/overview.rst
+++ b/source/reference/v2/terminals-api/overview.rst
@@ -1,11 +1,7 @@
 Terminals API
 =============
-.. customize-document-title::
-   :beta: true
-
-.. note:: The Terminals API is currently in beta. If you are interested in offering point-of-sale payments, please see
-   `this page <https://www.mollie.com/products/payments-terminal>`_ for more information on our product offering. Once
-   there, you can register your interest to be kept up-to-date.
+.. note:: If you are interested in offering point-of-sale payments, please see
+   `this page <https://www.mollie.com/products/payments-terminal>`_ for more information on our product offering.
 
 If you process point-of-sale payments with Mollie, the Terminals API allows you to manage your point-of-sale devices.
 

--- a/source/theme/sidebar-reference-v2.html
+++ b/source/theme/sidebar-reference-v2.html
@@ -184,7 +184,7 @@
   {%- set current = pagename.startswith('reference/v2/terminals-api/') -%}
   <li class="sidebar__item sidebar__group {%- if pagename.startswith('reference/v2/terminals-api/') %} current{% endif %}">
     <a href="{{ pathto('reference/v2/terminals-api/overview') }}"
-       class="{% if pagename == 'reference/v2/terminals-api/overview' %}current{% endif %}">Terminals API <span class="api-name__beta">BETA</span></a>
+       class="{% if pagename == 'reference/v2/terminals-api/overview' %}current{% endif %}">Terminals API</a>
 
     {%- if pagename.startswith('reference/v2/terminals-api/') %}
       <ul>


### PR DESCRIPTION
The terminals API is no longer in Beta anymore. The mollie In-Person Payments solution is now available for everyone (who is eligible). This branch removes the beta flag from the terminals api pages.