### PR TITLE
docs: remove duplicate word

### DIFF
--- a/source/reference/v2/payments-api/create-payment.rst
+++ b/source/reference/v2/payments-api/create-payment.rst
@@ -418,8 +418,8 @@ Bank transfer
    :condition: optional
 
    Consumer's email address, to automatically send the bank transfer details to. **Note:** the payment instructions will
-   will be sent immediately when creating the payment. If you do not specify the ``locale`` parameter, the email will be
-   sent in English, as we haven't yet been able to detect the consumer's browser language.
+   be sent immediately when creating the payment. If you do not specify the ``locale`` parameter, the email will be sent 
+   in English, as we haven't yet been able to detect the consumer's browser language.
 
 .. parameter:: dueDate
    :type: string


### PR DESCRIPTION
The word `will` is duplicated in https://docs.mollie.com/reference/v2/payments-api/create-payment#payment-method-specific-parameters

![image](https://github.com/mollie/api-documentation/assets/173716/ce37a120-4666-4f00-b797-08991a7ef694)
